### PR TITLE
fix: force-delete-pool event is not empty

### DIFF
--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc,
  [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.1.14"},
+  {vsn, "0.1.15"},
   {registered, []},
   {applications, [kernel,
                   stdlib,

--- a/src/ehttpc_pool.erl
+++ b/src/ehttpc_pool.erl
@@ -106,7 +106,7 @@ terminate(_Reason, #state{name = Pool, size = Size}) ->
       fun(I) ->
               gproc_pool:remove_worker(ehttpc:name(Pool), {Pool, I})
       end, lists:seq(1, Size)),
-    gproc_pool:delete(ehttpc:name(Pool)).
+    gproc_pool:force_delete(ehttpc:name(Pool)).
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.


### PR DESCRIPTION
```erlang
(emqx@x)77> gproc_pool:delete(ehttpc:name(emqx_modules_acl_http)).
** exception error: not_empty
     in function  gproc_pool:call/1 (gproc_pool.erl, line 636)
(emqx@x)78> gproc_pool:delete(ehttpc:name(emqx_modules_supper_http)).
** exception error: not_empty
     in function  gproc_pool:call/1 (gproc_pool.erl, line 636)
(emqx@x)79> gproc_pool:force_delete(ehttpc:name(emqx_modules_supper_http)).
true
(emqx@x)82> gproc_pool:force_delete(ehttpc:name(emqx_modules_acl_http)).
true
(emqx@x)83> gproc_pool:force_delete(ehttpc:name(emqx_modules_auth_http)).
true
```
Sometimes the pool can't be deleted when is not empty.  we must force_delete it.

