### PR TITLE
perf: collect gen calls to queue

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -24,6 +24,10 @@ jobs:
     - name: Compile
       run: rebar3 compile
     - name: Run tests
-      run: rebar3 do eunit
+      run: make eunit
+    - name: Run dialyzer
+      run: make dialyzer
     - name: Ensure version consistency
       run: ./check_vsns.escript
+    - name: Ensure style
+      run: ./check-style.sh

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ _checkouts/
 
 rebar.lock
 rebar3.crashdump
+snabbkaffe/

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,10 @@
 
 REBAR=rebar3
 
-all: deps compile xref
-
-deps:
-	@$(REBAR) get-deps
+all: compile eunit xref dialyzer
 
 compile:
 	@$(REBAR) compile
-
 xref:
 	@$(REBAR) xref
 
@@ -25,5 +21,9 @@ cover:
 edoc:
 	@$(REBAR) edoc
 
-dialyzer: compile
+dialyzer:
 	@$(REBAR) dialyzer
+
+eunit:
+	@$(REBAR) eunit -v -c
+	@$(REBAR) cover

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,15 @@
+# ehttpc changes
+
+## 0.2.0
+
+* Major refactoring on top of 0.1.15
+  - Added test cases.
+  - Support hot upgrade from all 0.1.X versions.
+  - No lower level retry (in 'gun' the http client lib).
+  - Now `enable_pipelining` can be an integer to indicate the number of HTTP requests
+    can be sent on wire before receiving responses (like the inflight-window).
+    `enable_pipelining=true` has the same effect as `enable_pipelining=100` and
+    `enable_pipelining=false` has the same effect as `enable_pipelining=1`
+  - Now all requests are async, so the `ehttpc:request` calls can be collected
+    from mailbox into process state, this makes the handling of gun responses
+    more effecient.

--- a/check-style.sh
+++ b/check-style.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+rebar3 fmt -w 'src/ehttpc.erl'
+rebar3 fmt -w 'test/*.erl'
+rebar3 fmt -w rebar.config
+
+DIFF_FILES="$(git diff --name-only)"
+if [ "$DIFF_FILES" != '' ]; then
+    echo "ERROR: Below files need reformat"
+    echo "$DIFF_FILES"
+    exit 1
+fi

--- a/rebar.config
+++ b/rebar.config
@@ -1,29 +1,34 @@
 {minimum_otp_vsn, "21.0"}.
 
-{deps,
- [{gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
-  {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
- ]}.
+{deps, [
+    {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
+    {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}},
+    {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.18.0"}}}
+]}.
 
-{erl_opts, [warn_unused_vars,
-            warn_shadow_vars,
-            warn_unused_import,
-            warn_obsolete_guard,
-            compressed, %% for edge
-            warnings_as_errors,
-            {parse_transform}
-           ]}.
+{erl_opts, [
+    warn_unused_vars,
+    warn_shadow_vars,
+    warn_unused_import,
+    warn_obsolete_guard,
+    warnings_as_errors,
+    %% for edge
+    compressed
+]}.
 
 {edoc_opts, [{preprocess, true}]}.
 
-{xref_checks, [undefined_function_calls, undefined_functions,
-               locals_not_used, deprecated_function_calls,
-               warnings_as_errors, deprecated_functions
-              ]}.
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used,
+    deprecated_function_calls,
+    warnings_as_errors,
+    deprecated_functions
+]}.
 
 {cover_enabled, true}.
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
 
-{plugins, [rebar3_proper]}.
-
+{plugins, [rebar3_proper, erlfmt]}.

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc,
  [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.1.15"},
+  {vsn, "0.2.0"},
   {registered, []},
   {applications, [kernel,
                   stdlib,
@@ -10,6 +10,6 @@
   {mod, {ehttpc_app, []}},
   {env, []},
   {licenses,["Apache-2.0"]},
-  {maintainers, ["EMQ X Team <contact@emqx.io>"]},
+  {maintainers, ["EMQX Team <contact@emqx.io>"]},
   {links,[{"Github", "https://github.com/emqx/ehttpc"}]}
  ]}.

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,35 +1,33 @@
 %% -*-: erlang -*-
-{"0.1.15",
+{"0.2.0",
    [
      {<<"0\\.1\\\.[0-7]">>, [
        {update, ehttpc, {advanced, []}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
      ]},
-     {<<"0\\.1\\.([8-9]|(1[0-3]))">>, [
-       {load_module, ehttpc, brutal_purge, soft_purge, []},
+     {<<"0\\.1\\.([8-9]|(1[0-4]))">>, [
+       {update, ehttpc, {advanced, []}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
      ]},
-     {"0.1.14", [
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
-     ]},
-     {<<".*">>, []}
+     {"0.1.15", [
+       {update, ehttpc, {advanced, []}}
+     ]}
    ],
    [
      {<<"0\\.1\\.0">>, [
-       {update, ehttpc, {advanced, [no_requests, no_enable_pipelining]}},
+       {update, ehttpc, {advanced, [no_requests]}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.[1-7]">>, [
        {update, ehttpc, {advanced, [no_enable_pipelining]}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
      ]},
-     {<<"0\\.1\\.([8-9]|(1[0-3]))">>, [
-       {load_module, ehttpc, brutal_purge, soft_purge, []},
+     {<<"0\\.1\\.([8-9]|(1[0-4]))">>, [
+       {update, ehttpc, {advanced, [downgrade_requests]}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
      ]},
-     {"0.1.14", [
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
-     ]},
-     {<<".*">>, []}
+     {"0.1.15", [
+       {update, ehttpc, {advanced, [downgrade_requests]}}
+     ]}
    ]
 }.

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -19,71 +19,110 @@
 -behaviour(gen_server).
 
 %% APIs
--export([ start_link/3
-        , request/3
-        , request/4
-        , request/5
-        , workers/1
-        , name/1
-        ]).
+-export([
+    start_link/3,
+    request/3,
+    request/4,
+    request/5,
+    workers/1,
+    name/1
+]).
 
 %% gen_server callbacks
--export([ init/1
-        , handle_call/3
-        , handle_cast/2
-        , handle_info/2
-        , terminate/2
-        , code_change/3
-        ]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3,
+    format_status/2,
+    format_state/2
+]).
+
+%% for test
+-export([
+    get_state/1,
+    get_state/2,
+    upgrade_requests/1,
+    downgrade_requests/1
+]).
+
+-export_type([
+    pool_name/0,
+    option/0
+]).
+
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(LOG(Level, Format, Args), logger:Level("ehttpc: " ++ Format, Args)).
+-define(REQ_CALL(Method, Req, ExpireAt), {Method, Req, ExpireAt}).
+-define(PEND_REQ(From, Req), {From, Req}).
+-define(SENT_REQ(StreamRef, ExpireAt, Acc), {StreamRef, ExpireAt, Acc}).
+-define(GEN_CALL_REQ(From, Call), {'$gen_call', From, ?REQ_CALL(_, _, _) = Call}).
+-define(undef, undefined).
 
 -record(state, {
-          pool              :: term(),
-          id                :: pos_integer(),
-          client            :: pid() | undefined,
-          mref              :: reference() | undefined,
-          host              :: inet:hostname() | inet:ip_address(),
-          port              :: inet:port_number(),
-          enable_pipelining :: boolean(),
-          gun_opts          :: proplists:proplist(),
-          gun_state         :: down | up,
-          requests          :: map()
-         }).
+    pool :: term(),
+    id :: pos_integer(),
+    client :: pid() | ?undef,
+    mref :: reference() | ?undef,
+    host :: inet:hostname() | inet:ip_address(),
+    port :: inet:port_number(),
+    enable_pipelining :: boolean() | non_neg_integer(),
+    gun_opts :: gun:opts(),
+    gun_state :: down | up,
+    requests :: map()
+}).
+
+-type pool_name() :: atom().
+-type option() :: [{atom(), term()}].
 
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
 
+%% @doc For test, debug and troubleshooting.
+get_state(PoolOrWorker) ->
+    get_state(PoolOrWorker, minimal).
+
+%% @doc For test, debug and troubleshooting.
+get_state(Pool, Style) when is_atom(Pool) ->
+    Worker = ehttpc_pool:pick_worker(Pool),
+    {Worker, get_state(Worker, Style)};
+get_state(Worker, Style) when is_pid(Worker) ->
+    State = sys:get_state(Worker),
+    format_state(State, Style).
+
 start_link(Pool, Id, Opts) ->
     gen_server:start_link(?MODULE, [Pool, Id, Opts], []).
 
 request(Pool, Method, Request) ->
-    request(Pool, Method, Request, 5000, 3).
+    request(Pool, Method, Request, 5000).
 
 request(Pool, Method, Request, Timeout) ->
-    request(Pool, Method, Request, Timeout, 3).
+    request(Pool, Method, Request, Timeout, 2).
 
 request(Pool, Method, Request, Timeout, Retry) when is_atom(Pool) ->
     request(ehttpc_pool:pick_worker(Pool), Method, Request, Timeout, Retry);
-
 request({Pool, N}, Method, Request, Timeout, Retry) when is_atom(Pool) ->
     request(ehttpc_pool:pick_worker(Pool, N), Method, Request, Timeout, Retry);
-
 request(Worker, Method, Request, Timeout, Retry) when is_pid(Worker) ->
     ExpireAt = now_() + Timeout,
-    try gen_server:call(Worker, {Method, Request, ExpireAt}, Timeout + 1000) of
+    try gen_server:call(Worker, ?REQ_CALL(Method, Request, ExpireAt), Timeout + 500) of
         %% gun will reply {gun_down, _Client, _, normal, _KilledStreams, _} message
         %% when connection closed by keepalive
-        {error, Reason} when Retry =< 1 ->
+        {error, Reason} when Retry < 1 ->
             {error, Reason};
         {error, _} ->
             request(Worker, Method, Request, Timeout, Retry - 1);
         Other ->
             Other
     catch
-        exit : {timeout, _Details} ->
-            {error, timeout}
+        exit:{timeout, _Details} ->
+            {error, timeout};
+        exit:Reason ->
+            {error, {ehttpc_worker_down, Reason}}
     end.
 
 workers(Pool) ->
@@ -97,210 +136,239 @@ name(Pool) -> {?MODULE, Pool}.
 
 init([Pool, Id, Opts]) ->
     process_flag(trap_exit, true),
-    State = #state{pool = Pool,
-                   id = Id,
-                   client = undefined,
-                   mref = undefined,
-                   host = proplists:get_value(host, Opts),
-                   port = proplists:get_value(port, Opts),
-                   enable_pipelining = proplists:get_value(enable_pipelining, Opts, false),
-                   gun_opts = gun_opts(Opts),
-                   gun_state = down,
-                   requests = #{}},
+    PrioLatest = proplists:get_bool(prioritise_latest, Opts),
+    State = #state{
+        pool = Pool,
+        id = Id,
+        client = ?undef,
+        mref = ?undef,
+        host = proplists:get_value(host, Opts),
+        port = proplists:get_value(port, Opts),
+        enable_pipelining = proplists:get_value(enable_pipelining, Opts, false),
+        gun_opts = gun_opts(Opts),
+        gun_state = down,
+        requests = #{
+            pending => queue:new(),
+            pending_count => 0,
+            sent => #{},
+            prioritise_latest => PrioLatest
+        }
+    },
     true = gproc_pool:connect_worker(ehttpc:name(Pool), {Pool, Id}),
     {ok, State}.
 
-handle_call(Request = {_, _, _}, From, State = #state{client = undefined, gun_state = down}) ->
-    case open(State) of
-        {ok, NewState} ->
-            handle_call(Request, From, NewState);
-        {error, Reason} ->
-            {reply, {error, Reason}, State}
-    end;
+handle_call(?REQ_CALL(_Method, _Request, _ExpireAt) = Req, From, State0) ->
+    State1 = enqueue_req(From, Req, upgrade_requests(State0)),
+    State = maybe_shoot(State1),
+    {noreply, State};
+handle_call(Call, _From, State0) ->
+    State = maybe_shoot(upgrade_requests(State0)),
+    {reply, {error, {unexpected_call, Call}}, State}.
 
-handle_call(Request = {_, _, ExpireAt}, From, State = #state{client = Client, mref = MRef, gun_state = down}) when is_pid(Client) ->
-    case (Timeout = ExpireAt - now_()) > 0 of
-        true ->
-            case gun:await_up(Client, Timeout, MRef) of
-                {ok, _} ->
-                    handle_call(Request, From, State#state{gun_state = up});
-                {error, timeout} ->
-                    {reply, {error, timeout}, State};
-                {error, Reason} ->
-                    true = erlang:demonitor(MRef, [flush]),
-                    {reply, {error, Reason}, State#state{client = undefined, mref = undefined}}
-            end;
-        false ->
-            {noreply, State}
-    end;
-
-handle_call({Method, Request, ExpireAt}, From, State = #state{client = Client,
-                                                              requests = Requests,
-                                                              enable_pipelining = EnablePipelining,
-                                                              gun_state = up}) when is_pid(Client) ->
-    case (Timeout = ExpireAt - now_()) > 0 of
-        true ->
-            StreamRef = do_request(Client, Method, Request),
-            case EnablePipelining of
-                true ->
-                    {noreply, State#state{requests = maps:put(StreamRef, {From, ExpireAt, undefined}, Requests)}};
-                false ->
-                    await_response(StreamRef, ExpireAt, Timeout, State)
-            end;
-        false ->
-            {noreply, State}
-    end;
-
-handle_call(Request, _From, State) ->
-    ?LOG(error, "Unexpected call: ~p", [Request]),
-    {reply, ignored, State}.
-
-handle_cast(Msg, State) ->
-    ?LOG(error, "Unexpected cast: ~p", [Msg]),
+handle_cast(_Msg, State0) ->
+    State = maybe_shoot(upgrade_requests(State0)),
     {noreply, State}.
 
-handle_info({gun_response, Client, _StreamRef, _IsFin, _StatusCode, _Headers}, State = #state{client = Client, enable_pipelining = false}) ->
-    {noreply, State};
-handle_info({gun_response, Client, StreamRef, IsFin, StatusCode, Headers}, State = #state{client = Client, requests = Requests, enable_pipelining = true}) ->
-    Now = now_(),
-    case maps:take(StreamRef, Requests) of
-        error ->
-            ?LOG(error, "Received 'gun_response' message from unknown stream ref: ~p", [StreamRef]),
-            {noreply, State};
-        {{_, ExpireAt, _}, NRequests} when Now > ExpireAt ->
-            cancel_stream(Client, StreamRef),
-            {noreply, State#state{requests = NRequests}};
-        {{From, ExpireAt, undefined}, NRequests} ->
-            case IsFin of
-                fin ->
-                    gen_server:reply(From, {ok, StatusCode, Headers}),
-                    {noreply, State#state{requests = NRequests}};
-                nofin ->
-                    {noreply, State#state{requests = NRequests#{StreamRef => {From, ExpireAt, {StatusCode, Headers, <<>>}}}}}
-            end;
-        _ ->
-            ?LOG(error, "Received 'gun_response' message does not match the state", []),
-            {noreply, State}
-    end;
+handle_info(Info, State0) ->
+    State1 = do_handle_info(Info, upgrade_requests(State0)),
+    State = maybe_shoot(State1),
+    {noreply, State}.
 
-handle_info({gun_data, Client, _StreamRef, _IsFin, _Data}, State = #state{client = Client, enable_pipelining = false}) ->
-    {noreply, State};
-handle_info({gun_data, Client, StreamRef, IsFin, Data}, State = #state{client = Client, requests = Requests, enable_pipelining = true}) ->
-    Now = now_(),
-    case maps:take(StreamRef, Requests) of
+do_handle_info(
+    {gun_response, Client, StreamRef, IsFin, StatusCode, Headers},
+    #state{client = Client} = State
+) ->
+    handle_gun_reply(State, Client, StreamRef, IsFin, StatusCode, Headers, ?undef);
+do_handle_info(
+    {gun_data, Client, StreamRef, IsFin, Data},
+    #state{client = Client} = State
+) ->
+    handle_gun_reply(State, Client, StreamRef, IsFin, ?undef, ?undef, Data);
+do_handle_info(
+    {gun_error, Client, StreamRef, Reason},
+    State = #state{client = Client, requests = Requests}
+) ->
+    case take_sent_req(StreamRef, Requests) of
         error ->
-            ?LOG(error, "Received 'gun_data' message from unknown stream ref: ~p", [StreamRef]),
-            {noreply, State};
-        {{_, ExpireAt, _}, NRequests} when Now > ExpireAt ->
-            cancel_stream(Client, StreamRef),
-            {noreply, State#state{requests = NRequests}};
-        {{From, ExpireAt, {StatusCode, Headers, Acc}}, NRequests} ->
-            case IsFin of
-                fin ->
-                    gen_server:reply(From, {ok, StatusCode, Headers, <<Acc/binary, Data/binary>>}),
-                    {noreply, State#state{requests = NRequests}};
-                nofin ->
-                    {noreply, State#state{requests = NRequests#{StreamRef => {From, ExpireAt, {StatusCode, Headers, <<Acc/binary, Data/binary>>}}}}}
-            end;
-        _ ->
-            ?LOG(error, "Received 'gun_data' message does not match the state", []),
-            {noreply, State}
-    end;
-
-handle_info({gun_error, Client, _StreamRef, _Reason}, State = #state{client = Client, enable_pipelining = false}) ->
-    {noreply, State};
-handle_info({gun_error, Client, StreamRef, Reason}, State = #state{client = Client, requests = Requests, enable_pipelining = true}) ->
-    Now = now_(),
-    case maps:take(StreamRef, Requests) of
-        error ->
-            ?LOG(error, "Received 'gun_error' message from unknown stream ref: ~p~n", [StreamRef]),
-            {noreply, State};
-        {{_, ExpireAt, _}, NRequests} when Now > ExpireAt ->
-            {noreply, State#state{requests = NRequests}};
-        {{From, _, _}, NRequests} ->
+            % Received 'gun_error' message from unknown stream
+            % this may happen when the async cancel stream is sent too late
+            % e.g. after the stream has been closed by gun, if we send a cancel stream
+            % gun will reply with Reason={badstate,"The stream cannot be found."}
+            State;
+        {expired, NRequests} ->
+            State#state{requests = NRequests};
+        {?SENT_REQ(From, _, _), NRequests} ->
             gen_server:reply(From, {error, Reason}),
-            {noreply, State#state{requests = NRequests}}
+            State#state{requests = NRequests}
     end;
+do_handle_info({gun_up, Client, _}, State = #state{client = Client}) ->
+    %% stale gun up after the caller gave up waiting in gun_await_up/5
+    %% we can only hope it to be useful for the next call
+    State#state{gun_state = up};
+do_handle_info(
+    {gun_down, Client, _, Reason, KilledStreams, _},
+    State = #state{client = Client}
+) ->
+    Reason =/= normal andalso Reason =/= closed andalso
+        ?LOG(warning, "Received 'gun_down' message with reason: ~p", [Reason]),
+    NewState = handle_gun_down(State, KilledStreams, Reason),
+    NewState;
+do_handle_info(
+    {'DOWN', MRef, process, Client, Reason},
+    State = #state{mref = MRef, client = Client}
+) ->
+    handle_client_down(State, Reason);
+do_handle_info(Info, State) ->
+    ?LOG(warning, "~p unexpected_info: ~p", [?MODULE, Info]),
+    State.
 
-handle_info({gun_up, Client, _}, State = #state{client = Client}) ->
-    {noreply, State#state{gun_state = up}};
-
-handle_info({gun_down, Client, _, _Reason, _KilledStreams, _}, State = #state{client = Client, enable_pipelining = false}) ->
-    {noreply, State#state{gun_state = down, requests = #{}}};
-handle_info({gun_down, Client, _, Reason, KilledStreams, _}, State = #state{client = Client, requests = Requests, enable_pipelining = true}) ->
-    Reason =/= normal andalso Reason =/= closed andalso ?LOG(warning, "Received 'gun_down' message with reason: ~p", [Reason]),
-    Now = now_(),
-    NRequests = lists:foldl(fun(StreamRef, Acc) ->
-                                case maps:take(StreamRef, Acc) of
-                                    error ->
-                                        Acc;
-                                    {{_, ExpireAt, _}, NAcc} when Now > ExpireAt ->
-                                        NAcc;
-                                    {{From, _, _}, NAcc} ->
-                                        gen_server:reply(From, {error, Reason}),
-                                        NAcc
-                                end
-                            end, Requests, KilledStreams),
-    {noreply, State#state{gun_state = down, requests = NRequests}};
-
-handle_info({'DOWN', MRef, process, Client, Reason}, State = #state{mref = MRef, client = Client, requests = Requests, enable_pipelining = EnablePipelining}) ->
-    true = erlang:demonitor(MRef, [flush]),
-    case EnablePipelining of
-        true ->
-            Now = now_(),
-            lists:foreach(fun({_, {_, ExpireAt, _}}) when Now > ExpireAt ->
-                              ok;
-                             ({_, {From, _, _}}) ->
-                              gen_server:reply(From, {error, Reason})
-                          end, maps:to_list(Requests));
-        false ->
-            ok
-    end,
-    case open(State#state{requests = #{}}) of
-        {ok, NewState} ->
-            {noreply, NewState};
-        {error, _Reason} ->
-            {noreply, State#state{mref = undefined, client = undefined}}
-    end;
-
-handle_info(Info, State) ->
-    ?LOG(error, "Unexpected info: ~p", [Info]),
-    {noreply, State}.
-
-terminate(_Reason, #state{pool = Pool, id = Id}) ->
+terminate(_Reason, #state{pool = Pool, id = Id, client = Client}) ->
+    is_pid(Client) andalso gun:close(Client),
     gproc_pool:disconnect_worker(ehttpc:name(Pool), {Pool, Id}),
     ok.
 
-code_change({down, _Vsn}, {state, Pool, ID, Client, MRef, Host, Port, _, GunOpts, GunState, _}, [no_requests, no_enable_pipelining]) ->
+%% NOTE: the git tag 0.1.0 was re-tagged
+%% the actual version in use in EMQX 4.2 had requests missing
+code_change({down, _Vsn}, State, [no_requests]) ->
+    %% downgrage to a version before 'requests' and 'enable_pipelining' were added
+    #state{
+        pool = Pool,
+        id = ID,
+        client = Client,
+        mref = MRef,
+        host = Host,
+        port = Port,
+        gun_opts = GunOpts,
+        gun_state = GunState
+    } = State,
     {ok, {state, Pool, ID, Client, MRef, Host, Port, GunOpts, GunState}};
-code_change({down, _Vsn}, {state, Pool, ID, Client, MRef, Host, Port, _, GunOpts, GunState, Requests}, [no_enable_pipelining]) ->
-    {ok, {state, Pool, ID, Client, MRef, Host, Port, GunOpts, GunState, Requests}};
+code_change({down, _Vsn}, State, [no_enable_pipelining]) ->
+    %% downgrade to a version before 'enable_pipelining' was added
+    #state{
+        pool = Pool,
+        id = ID,
+        client = Client,
+        mref = MRef,
+        host = Host,
+        port = Port,
+        gun_opts = GunOpts,
+        gun_state = GunState,
+        requests = Requests
+    } = State,
+    OldRequests = downgrade_requests(Requests),
+    {ok, {state, Pool, ID, Client, MRef, Host, Port, GunOpts, GunState, OldRequests}};
+code_change({down, _Vsn}, #state{requests = Requests} = State, [downgrade_requests]) ->
+    %% downgrade to a version which had old format 'requests'
+    OldRequests = downgrade_requests(Requests),
+    {ok, State#state{requests = OldRequests}};
+%% below are upgrade instructions
 code_change(_Vsn, {state, Pool, ID, Client, MRef, Host, Port, GunOpts, GunState}, _Extra) ->
-    {ok, {state, Pool, ID, Client, MRef, Host, Port, true, GunOpts, GunState, #{}}};
-code_change(_Vsn, {state, Pool, ID, Client, MRef, Host, Port, GunOpts, GunState, Requests}, _Extra) ->
-    {ok, {state, Pool, ID, Client, MRef, Host, Port, true, GunOpts, GunState, Requests}}.
+    %% upgrade from a version before 'requests' field was added
+    {ok, #state{
+        pool = Pool,
+        id = ID,
+        client = Client,
+        mref = MRef,
+        host = Host,
+        port = Port,
+        enable_pipelining = true,
+        gun_opts = GunOpts,
+        gun_state = GunState,
+        requests = upgrade_requests(#{})
+    }};
+code_change(_Vsn, {state, Pool, ID, Client, MRef, Host, Port, GunOpts, GunState, Requests}, _) ->
+    %% upgrade from a version before 'enable_pipelining' filed was added
+    {ok, #state{
+        pool = Pool,
+        id = ID,
+        client = Client,
+        mref = MRef,
+        host = Host,
+        port = Port,
+        enable_pipelining = true,
+        gun_opts = GunOpts,
+        gun_state = GunState,
+        requests = upgrade_requests(Requests)
+    }};
+code_change(_Vsn, State, _) ->
+    %% upgrade from a version ahving old format 'requests' field
+    {ok, upgrade_requests(State)}.
+
+format_status(_Opt, [_PDict, State]) ->
+    format_state(State, minimal).
 
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
 
+format_state(State, Style) ->
+    Fields = record_info(fields, state),
+    Map = maps:from_list(lists:zip(Fields, tl(tuple_to_list(State)))),
+    case Style of
+        normal -> Map;
+        minimal -> Map#{requests => summary_requests(maps:get(requests, Map))}
+    end.
+
+summary_requests(#{sent := Sent} = Reqs) ->
+    Reqs#{
+        pending => {"..."},
+        sent => maps:size(Sent)
+    }.
+
+handle_client_down(#state{requests = Requests0} = State, Reason) ->
+    ?tp(?FUNCTION_NAME, Requests0),
+    Requests = reply_error_for_sent_reqs(Requests0, Reason),
+    State#state{
+        requests = Requests,
+        mref = ?undef,
+        client = ?undef,
+        gun_state = down
+    }.
+
+handle_gun_down(#state{requests = Requests} = State, KilledStreams, Reason) ->
+    ?tp(?FUNCTION_NAME, #{requests => Requests, reason => Reason}),
+    NRequests =
+        lists:foldl(
+            fun(StreamRef, Acc) ->
+                case take_sent_req(StreamRef, Acc) of
+                    error ->
+                        Acc;
+                    {expired, NAcc} ->
+                        NAcc;
+                    {?SENT_REQ(From, _, _), NAcc} ->
+                        gen_server:reply(From, {error, Reason}),
+                        NAcc
+                end
+            end,
+            Requests,
+            KilledStreams
+        ),
+    State#state{requests = NRequests, gun_state = down}.
+
 open(State = #state{host = Host, port = Port, gun_opts = GunOpts}) ->
     case gun:open(Host, Port, GunOpts) of
         {ok, ConnPid} when is_pid(ConnPid) ->
-            MRef = monitor(process, ConnPid),
+            MRef = erlang:monitor(process, ConnPid),
             {ok, State#state{mref = MRef, client = ConnPid}};
         {error, Reason} ->
             {error, Reason}
     end.
 
 gun_opts(Opts) ->
-    gun_opts(Opts, #{retry => 5,
-                     retry_timeout => 1000,
-                     connect_timeout => 5000,
-                     %% The keepalive mechanism of gun will send "\r\n" for keepalive,
-                     %% which may cause misjudgment by some servers, so we disabled it by default
-                     http_opts => #{keepalive => infinity},
-                     protocols => [http]}).
+    %% We do not allow gun to retry,
+    %% because we have retry around the gen_server call
+    %% retry at lower level will likely cause
+    %% gen_server callers to time out anyway
+    GunNoRetry = 0,
+    gun_opts(Opts, #{
+        retry => GunNoRetry,
+        retry_timeout => 1000,
+        connect_timeout => 5000,
+        %% The keepalive mechanism of gun will send "\r\n" for keepalive,
+        %% which may cause misjudgment by some servers, so we disabled it by default
+        http_opts => #{keepalive => infinity},
+        protocols => [http]
+    }).
 
 gun_opts([], Acc) ->
     Acc;
@@ -317,6 +385,10 @@ gun_opts([{transport_opts, TransportOpts} | Opts], Acc) ->
 gun_opts([_ | Opts], Acc) ->
     gun_opts(Opts, Acc).
 
+do_request(Client, head, {Path, Headers}) ->
+    gun:head(Client, Path, Headers);
+do_request(Client, head, Path) ->
+    do_request(Client, head, {Path, []});
 do_request(Client, get, {Path, Headers}) ->
     gun:get(Client, Path, Headers);
 do_request(Client, post, {Path, Headers, Body}) ->
@@ -327,71 +399,267 @@ do_request(Client, delete, {Path, Headers}) ->
     gun:delete(Client, Path, Headers).
 
 cancel_stream(Client, StreamRef) ->
-    gun:cancel(Client, StreamRef),
-    flush_stream(Client, StreamRef).
+    %% this is just an async message sent to gun
+    %% the gun stream process does not really cancel
+    %% anything, but just mark the receiving process (i.e. self())
+    %% as inactive, however, there could be messages already
+    %% delivered to self()'s mailbox
+    %% or the stream process might send more messages
+    %% before receiving the cancel message.
+    _ = gun:cancel(Client, StreamRef),
+    ok.
 
-flush_stream(Client, StreamRef) ->
-    receive
-        {gun_response, Client, StreamRef, _, _, _} ->
-            flush_stream(Client, StreamRef);
-        {gun_data, Client, StreamRef, _, _} ->
-            flush_stream(Client, StreamRef);
-        {gun_error, Client, StreamRef, _} ->
-            flush_stream(Client, StreamRef)
-	after 0 ->
-		ok
-	end.
-
-await_response(StreamRef, ExpireAt, Timeout, State = #state{client = Client})
-  when Timeout > 0 ->
-    receive
-        {gun_response, Client, StreamRef, fin, StatusCode, Headers} ->
-           {reply, {ok, StatusCode, Headers}, State};
-        {gun_response, Client, StreamRef, nofin, StatusCode, Headers} ->
-            await_remaining_response(StreamRef, ExpireAt, State, {StatusCode, Headers, <<>>});
-        {gun_error, Client, StreamRef, Reason} ->
-            {reply, {error, Reason}, State};
-        {gun_down, Client, _, Reason, _KilledStreams, _} ->
-            {reply, {error, Reason}, State};
-        {'DOWN', MRef, process, Client, Reason} ->
-            true = erlang:demonitor(MRef, [flush]),
-            NState = case open(State) of
-                        {ok, State1} -> State1;
-                        {error, _Reason} -> State#state{mref = undefined, client = undefined}
-                    end,
-            {reply, {error, Reason}, NState}
-    after Timeout ->
-        cancel_stream(Client, StreamRef),
-        {reply, {error, timeout}, State}
-    end.
-
-await_remaining_response(StreamRef, ExpireAt, State = #state{client = Client, mref = MRef}, {StatusCode, Headers, Acc}) ->
-    case (Timeout = ExpireAt - now_()) > 0 of
-        true ->
-            receive
-                {gun_data, Client, StreamRef, fin, Data} ->
-                    {reply, {ok, StatusCode, Headers, <<Acc/binary, Data/binary>>}, State};
-                {gun_data, Client, StreamRef, nofin, Data} ->
-                    await_remaining_response(StreamRef, ExpireAt, State, {StatusCode, Headers, <<Acc/binary, Data/binary>>});
-                {gun_error, Client, StreamRef, Reason} ->
-                    {reply, {error, Reason}, State};
-                {gun_down, Client, _, Reason, _KilledStreams, _} ->
-                    {reply, {error, Reason}, State};
-                {'DOWN', MRef, process, Client, Reason} ->
-                    true = erlang:demonitor(MRef, [flush]),
-                    NState = case open(State) of
-                                {ok, State1} -> State1;
-                                {error, _Reason} -> State#state{mref = undefined, client = undefined}
-                            end,
-                    {reply, {error, Reason}, NState}
-            after Timeout ->
-                cancel_stream(Client, StreamRef),
-                {reply, {error, timeout}, State}
-            end;
-        false ->
-            cancel_stream(Client, StreamRef),
-            {noreply, State}
-    end.
+timeout(ExpireAt) ->
+    max(ExpireAt - now_(), 0).
 
 now_() ->
     erlang:system_time(millisecond).
+
+%% =================================================================================
+%% sent requests
+%% =================================================================================
+
+%% downgrade will cause all the pending calls to timeout
+downgrade_requests(#{pending := _PendingCalls, sent := Sent}) -> Sent;
+downgrade_requests(Already) -> Already.
+
+%% upgrade from old format before 0.1.16
+upgrade_requests(#state{requests = Requests} = State) ->
+    State#state{requests = upgrade_requests(Requests)};
+upgrade_requests(#{pending := _, sent := _} = Already) ->
+    Already;
+upgrade_requests(Map) when is_map(Map) ->
+    #{
+        pending => queue:new(),
+        pending_count => 0,
+        sent => Map,
+        prioritise_latest => false
+    }.
+
+put_sent_req(StreamRef, Req, #{sent := Sent} = Requests) ->
+    Requests#{sent := maps:put(StreamRef, Req, Sent)}.
+
+take_sent_req(StreamRef, #{sent := Sent} = Requests) ->
+    case maps:take(StreamRef, Sent) of
+        error ->
+            error;
+        {Req, NewSent} ->
+            case is_req_expired(Req, now_()) of
+                true ->
+                    {expired, Requests#{sent := NewSent}};
+                false ->
+                    {Req, Requests#{sent := NewSent}}
+            end
+    end.
+
+is_req_expired(?SENT_REQ({Pid, _Ref}, ExpireAt, _), Now) ->
+    Now > ExpireAt orelse (not erlang:is_process_alive(Pid)).
+
+%% reply error to all callers which are waiting for the sent reqs
+reply_error_for_sent_reqs(#{sent := Sent} = R, Reason) ->
+    Now = now_(),
+    lists:foreach(
+        fun({_, ?SENT_REQ(From, _, _) = Req}) ->
+            case is_req_expired(Req, Now) of
+                true ->
+                    ok;
+                false ->
+                    gen_server:reply(From, {error, Reason})
+            end
+        end,
+        maps:to_list(Sent)
+    ),
+    R#{sent := #{}}.
+
+%% allow 100 async requests maximum when enable_pipelining is 'true'
+%% allow only 1 async request when enable_pipelining is 'false'
+%% otherwise stop shooting at the number limited by enable_pipelining
+should_cool_down(true, Sent) -> Sent >= 100;
+should_cool_down(false, Sent) -> Sent > 0;
+should_cool_down(N, Sent) when is_integer(N) -> Sent >= N.
+
+drop_expired(#{pending_count := 0} = Requests) ->
+    Requests;
+drop_expired(#{pending := Pending, pending_count := PC} = Requests) ->
+    PrioLatest = maps:get(prioritise_latest, Requests, false),
+    {value, ?PEND_REQ(_, ?REQ_CALL(_, _, ExpireAt))} =
+        case PrioLatest of
+            true -> queue:peek_r(Pending);
+            false -> queue:peek(Pending)
+        end,
+    case now_() > ExpireAt of
+        true when PrioLatest ->
+            {_, NewPendings} = queue:out_r(Pending),
+            NewRequests = Requests#{pending => NewPendings, pending_count => PC - 1},
+            drop_expired(NewRequests);
+        true ->
+            {_, NewPendings} = queue:out(Pending),
+            NewRequests = Requests#{pending => NewPendings, pending_count => PC - 1},
+            drop_expired(NewRequests);
+        false ->
+            Requests
+    end.
+
+%% enqueue the pending requests
+enqueue_req(From, Req, #state{requests = Requests0} = State) ->
+    #{
+        pending := Pending,
+        pending_count := PC
+    } = Requests0,
+    NewPending =
+        case maps:get(prioritise_latest, Requests0, false) of
+            true -> queue:in_r(?PEND_REQ(From, Req), Pending);
+            false -> queue:in(?PEND_REQ(From, Req), Pending)
+        end,
+    Requests = Requests0#{pending := NewPending, pending_count := PC + 1},
+    State#state{requests = drop_expired(Requests)}.
+
+%% call gun to shoot the request out
+maybe_shoot(#state{enable_pipelining = EP, requests = Requests0, client = Client} = State0) ->
+    #{sent := Sent} = Requests0,
+    State = State0#state{requests = drop_expired(Requests0)},
+    %% If the gun http client is down
+    ClientDown = is_pid(Client) andalso (not is_process_alive(Client)),
+    %% Or when it too many has been sent already
+    case ClientDown orelse should_cool_down(EP, maps:size(Sent)) of
+        true ->
+            %% Then we should cool down, and let the gun responses
+            %% or 'DOWN' message to trigger the flow again
+            ?tp(cool_down, #{enable_pipelining => EP}),
+            State;
+        false ->
+            do_shoot(State)
+    end.
+
+do_shoot(#state{requests = #{pending_count := 0}} = State) ->
+    State;
+do_shoot(#state{requests = #{pending := Pending0, pending_count := N} = Requests0} = State0) ->
+    {{value, ?PEND_REQ(From, Req)}, Pending} = queue:out(Pending0),
+    Requests = Requests0#{pending := Pending, pending_count := N - 1},
+    State1 = State0#state{requests = Requests},
+    case shoot(Req, From, State1) of
+        {reply, Reply, State} ->
+            gen_server:reply(From, Reply),
+            %% continue shooting because there might be more
+            %% calls queued while evaluating handle_req/3
+            maybe_shoot(State);
+        {noreply, State} ->
+            maybe_shoot(State)
+    end.
+
+shoot(
+    Request = ?REQ_CALL(_, _, _),
+    From,
+    State = #state{client = ?undef, gun_state = down}
+) ->
+    %% no http client, start it
+    case open(State) of
+        {ok, NewState} ->
+            shoot(Request, From, NewState);
+        {error, Reason} ->
+            {reply, {error, Reason}, State}
+    end;
+shoot(
+    Request = ?REQ_CALL(_, _Req, ExpireAt),
+    From,
+    State0 = #state{client = Client, mref = MRef, gun_state = down}
+) when is_pid(Client) ->
+    Timeout = timeout(ExpireAt),
+    %% wait for the http client to be ready
+    {Res, State} = gun_await_up(Client, ExpireAt, Timeout, MRef, State0),
+    case Res of
+        {ok, _} ->
+            ?tp(gun_up, #{from => From, req => _Req}),
+            shoot(Request, From, State#state{gun_state = up});
+        {error, connect_timeout} ->
+            %% the caller can not wait logger
+            %% but the connection is likely to be useful
+            {reply, {error, connect_timeout}, State};
+        {error, Reason} ->
+            erlang:demonitor(MRef, [flush]),
+            {reply, {error, Reason}, State#state{client = ?undef, mref = ?undef}}
+    end;
+shoot(
+    ?REQ_CALL(Method, Request, ExpireAt),
+    From,
+    State = #state{
+        client = Client,
+        requests = Requests,
+        gun_state = up
+    }
+) when is_pid(Client) ->
+    case timeout(ExpireAt) > 0 of
+        true ->
+            StreamRef = do_request(Client, Method, Request),
+            ?tp(shot, #{from => From, req => Request, reqs => Requests}),
+            %% no need for the payload
+            Req = ?SENT_REQ(From, ExpireAt, ?undef),
+            {noreply, State#state{requests = put_sent_req(StreamRef, Req, Requests)}};
+        false ->
+            %% timedout already by the time when handing the call
+            {noreply, State}
+    end.
+
+%% This is a copy of gun:wait_up/3
+%% with the '$gen_call' clause added so the calls in the mail box
+%% are collected into the queue in time
+gun_await_up(Pid, ExpireAt, Timeout, MRef, State0) ->
+    receive
+        {gun_up, Pid, Protocol} ->
+            {{ok, Protocol}, State0};
+        {'DOWN', MRef, process, Pid, Reason} ->
+            {{error, Reason}, State0};
+        ?GEN_CALL_REQ(From, Call) ->
+            State = enqueue_req(From, Call, State0),
+            %% keep waiting
+            NewTimeout = timeout(ExpireAt),
+            gun_await_up(Pid, ExpireAt, NewTimeout, MRef, State)
+    after Timeout ->
+        {{error, connect_timeout}, State0}
+    end.
+
+%% normal handling of gun_response and gun_data reply
+handle_gun_reply(State, Client, StreamRef, IsFin, StatusCode, Headers, Data) ->
+    #state{requests = Requests} = State,
+    case take_sent_req(StreamRef, Requests) of
+        error ->
+            %% Received 'gun_data' message from unknown stream
+            %% this may happen when the async cancel stream is sent too late
+            State;
+        {expired, NRequests} ->
+            %% the call is expired, caller is no longer waiting for a reply
+            ok = cancel_stream(Client, StreamRef),
+            State#state{requests = NRequests};
+        {?SENT_REQ(From, ExpireAt, ?undef), NRequests} ->
+            %% gun_response, http head
+
+            %% assert, no body yet
+            ?undef = Data,
+            case IsFin of
+                fin ->
+                    %% only http heads no body
+                    gen_server:reply(From, {ok, StatusCode, Headers}),
+                    State#state{requests = NRequests};
+                nofin ->
+                    %% start accumulating data
+                    Req = ?SENT_REQ(From, ExpireAt, {StatusCode, Headers, []}),
+                    State#state{requests = put_sent_req(StreamRef, Req, NRequests)}
+            end;
+        {?SENT_REQ(From, ExpireAt, {StatusCode0, Headers0, Data0}), NRequests} ->
+            %% gun_data, http body
+
+            %% assert
+            ?undef = StatusCode,
+            %% assert
+            ?undef = Headers,
+            case IsFin of
+                fin ->
+                    gen_server:reply(
+                        From, {ok, StatusCode0, Headers0, iolist_to_binary([Data0, Data])}
+                    ),
+                    State#state{requests = NRequests};
+                nofin ->
+                    Req = ?SENT_REQ(From, ExpireAt, {StatusCode0, Headers0, [Data0, Data]}),
+                    State#state{requests = put_sent_req(StreamRef, Req, NRequests)}
+            end
+    end.

--- a/test/ehttpc_appup_tests.erl
+++ b/test/ehttpc_appup_tests.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -18,6 +18,13 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
+%% First version used in EMQX v4.3.0
+-record(state_0_1_0, {pool, id, client, mref, host, port, gun_opts, gun_state}).
+-record(state_0_1_7, {pool, id, client, mref, host, port, gun_opts, gun_state, requests}).
+-record(state_0_1_8, {
+    pool, id, client, mref, host, port, enable_pipelining, gun_opts, gun_state, requests
+}).
+
 app_vsn_test() ->
     {ok, [{AppupVsn, _Upgraes, _Downgrades}]} = file:consult("src/ehttpc.appup.src"),
     {ok, [{application, ehttpc, Props}]} = file:consult("src/ehttpc.app.src"),
@@ -30,6 +37,86 @@ ensure_vsn_bump_test() ->
     V = parse_semver(proplists:get_value(vsn, Props)),
     ?assert(TagV =< V).
 
+ensuer_changelog_test() ->
+    {ok, [{application, ehttpc, Props}]} = file:consult("src/ehttpc.app.src"),
+    Vsn = proplists:get_value(vsn, Props),
+    ExpectedChangeLogLine = "## " ++ Vsn,
+    {ok, Text} = file:read_file("changelog.md"),
+    Lines = binary:split(Text, <<"\n">>, [global]),
+    case lists:member(iolist_to_binary(ExpectedChangeLogLine), Lines) of
+        true -> ok;
+        false -> error({missing_changelog_for_vsn, ExpectedChangeLogLine})
+    end.
+
 parse_semver(Str) ->
     [Major, Minor, Patch | _] = string:tokens(Str, ".-"),
     {list_to_integer(Major), list_to_integer(Minor), list_to_integer(Patch)}.
+
+all_tags() ->
+    string:tokens(os:cmd("git tag"), "\n").
+
+git_tag_match_upgrade_vsn_test_() ->
+    {ok, [{_AppupVsn, Upgraes, Downgrades}]} = file:consult("src/ehttpc.appup.src"),
+    [{Tag, fun() -> true = has_a_match(Tag, Upgraes, Downgrades) end} || Tag <- all_tags()].
+
+has_a_match(Tag, Ups, Downs) ->
+    has_a_match(Tag, Ups) andalso
+        has_a_match(Tag, Downs).
+
+has_a_match(_, []) ->
+    false;
+has_a_match(Tag, [{Tag, _} | _]) ->
+    true;
+has_a_match(Tag, [{Re, _} | Rest]) when is_binary(Re) ->
+    case re:run(Tag, Re, [unicode, {capture, first, list}]) of
+        {match, [Tag]} -> true;
+        _ -> has_a_match(Tag, Rest)
+    end.
+
+%% NOTE: the git tag 0.1.0 was re-tagged
+upgrade_from_test_() ->
+    Old1 = #state_0_1_0{mref = make_ref()},
+    Old2 = #state_0_1_7{mref = make_ref(), requests = #{}},
+    Old3 = #state_0_1_8{mref = make_ref(), requests = #{}},
+    F = fun({Old, Extra}) ->
+        {ok, New} = ehttpc:code_change("old", new_tag(Old), []),
+        #{requests := Requests} = ehttpc:format_state(New, normal),
+        ?assertMatch(
+            #{
+                pending := _,
+                pending_count := 0,
+                sent := #{}
+            },
+            Requests
+        ),
+        {ok, Down} = ehttpc:code_change({down, "new"}, New, Extra),
+        OldTag = element(1, Old),
+        ?assertEqual(Old, old_tag(OldTag, Down))
+    end,
+    [
+        {atom_to_list(element(1, Old)), fun() -> F({Old, Extra}) end}
+     || {Old, Extra} <- [
+            {Old1, [no_requests]},
+            {Old2, [no_enable_pipelining]},
+            {Old3, [downgrade_requests]}
+        ]
+    ].
+
+old_tag(Tag, State) ->
+    setelement(1, State, Tag).
+
+new_tag(State) ->
+    setelement(1, State, state).
+
+upgrade_requests_test() ->
+    Old = #{foo => bar},
+    New = ehttpc:upgrade_requests(Old),
+    ?assertMatch(
+        #{
+            sent := Old,
+            pending := _,
+            pending_count := 0
+        },
+        New
+    ),
+    ?assertMatch(Old, ehttpc:downgrade_requests(New)).

--- a/test/ehttpc_google_tests.erl
+++ b/test/ehttpc_google_tests.erl
@@ -1,0 +1,101 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% run some tests against google.com
+-module(ehttpc_google_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(POOL, ?MODULE).
+
+-define(HOST, "google.com").
+-define(PORT, 80).
+-define(PATH, <<"/">>).
+-define(METHOD, get).
+-define(POOL_SIZE, 1).
+
+concurrent_callers_test_() ->
+    N = 1000,
+    TestTimeout = 10,
+    Host = ?HOST,
+    Port = ?PORT,
+    %%                host  port  enable_pipelining prioritise_latest
+    Opts1 = pool_opts(Host, Port, true, true),
+    Opts2 = pool_opts(Host, Port, true, false),
+    Opts3 = pool_opts(Host, Port, false, true),
+    Opts4 = pool_opts(Host, Port, false, false),
+    F = fun() -> req_async(?METHOD, N) end,
+    [
+        {timeout, TestTimeout, fun() -> with_pool(Opts1, F) end},
+        {timeout, TestTimeout, fun() -> with_pool(Opts2, F) end},
+        {timeout, TestTimeout, fun() -> with_pool(Opts3, F) end},
+        {timeout, TestTimeout, fun() -> with_pool(Opts4, F) end}
+    ].
+
+req(get) ->
+    {?PATH, [{<<"Connection">>, <<"Keep-Alive">>}]};
+req(post) ->
+    {?PATH, [{<<"Connection">>, <<"Keep-Alive">>}],
+        term_to_binary(io_lib:format("~0p: ~0p~n", [erlang:system_time(), self()]))}.
+
+req_sync(_Method, 0, _Timeout) ->
+    ok;
+req_sync(Method, N, Timeout) ->
+    case ehttpc:request(?POOL, Method, req(Method), Timeout, _Retry = 0) of
+        {ok, _, _Headers, _Body} -> ok;
+        {error, timeout} -> timeout
+    end,
+    req_sync(Method, N - 1, Timeout).
+
+req_async(Method, N) ->
+    {Time, Results} = timer:tc(fun() -> req_async(Method, N, 5_000) end),
+    {OK, Timeout} = lists:partition(fun(I) -> I =:= ok end, Results),
+    io:format(
+        user,
+        "~n============~ntime: ~p OKs: ~p Timeouts ~p~n",
+        [Time, length(OK), length(Timeout)]
+    ).
+
+req_async(Method, N, Timeout) ->
+    L = lists:seq(1, N),
+    ehttpc_test_lib:parallel_map(
+        fun(_) ->
+            req_sync(Method, 1, Timeout)
+        end,
+        L
+    ).
+
+pool_opts(Host, Port, Pipeline, PrioLatest) ->
+    [
+        {host, Host},
+        {port, Port},
+        {enable_pipelining, Pipeline},
+        {pool_size, ?POOL_SIZE},
+        {pool_type, random},
+        {connect_timeout, 5000},
+        {retry, 0},
+        {retry_timeout, 1000},
+        {prioritise_latest, PrioLatest}
+    ].
+
+with_pool(Opts, F) ->
+    application:ensure_all_started(ehttpc),
+    try
+        {ok, _} = ehttpc_sup:start_pool(?POOL, Opts),
+        F()
+    after
+        ehttpc_sup:stop_pool(?POOL)
+    end.

--- a/test/ehttpc_server.erl
+++ b/test/ehttpc_server.erl
@@ -1,0 +1,201 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% @doc A dead simple HTTP server
+-module(ehttpc_server).
+
+-export([
+    start_link/1,
+    stop/1
+]).
+
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+%% public
+start_link(#{port := Port, name := Name} = Opts) ->
+    spawn_link(
+        fun() ->
+            register(Name, self()),
+            {ok, LSocket} = listen(Port),
+            io:format(user, "Stream HTTP Server started, listening on port ~p~n", [Port]),
+            Acceptor = spawn_link(fun() ->
+                ?tp(?MODULE, #{pid => self(), state => accepting}),
+                accept(LSocket, Opts)
+            end),
+            receive
+                stop ->
+                    unlink(Acceptor),
+                    gen_tcp:close(LSocket),
+                    exit(Acceptor, kill),
+                    exit(normal)
+            end
+        end
+    ).
+
+stop(undefined) ->
+    ok;
+stop(Name) when is_atom(Name) -> stop(whereis(Name));
+stop(Pid) ->
+    Mref = monitor(process, Pid),
+    Pid ! stop,
+    receive
+        {'DOWN', Mref, _, _, _} ->
+            ok
+    after 2000 ->
+        exit(Pid, kill),
+        ok
+    end.
+
+%% private
+accept(LSocket, Opts) ->
+    case gen_tcp:accept(LSocket) of
+        {ok, Socket} ->
+            spawn_link(fun() -> loop(Socket, Opts) end),
+            accept(LSocket, Opts);
+        {error, _Reason} ->
+            ok
+    end.
+
+count_requests([<<>>], N) ->
+    {N, <<>>};
+count_requests([Buffer], N) ->
+    {N, Buffer};
+count_requests([_ | T], N) ->
+    count_requests(T, N + 1).
+
+listen(Port) ->
+    Self = self(),
+    spawn_link(fun() ->
+        Options = [binary, {backlog, 4096}, {active, false}, {reuseaddr, true}],
+        Self ! gen_tcp:listen(Port, Options),
+        receive
+            _ ->
+                ok
+        end
+    end),
+    receive
+        {ok, LSocket} ->
+            {ok, LSocket}
+    end.
+
+loop(Socket, Opts) ->
+    loop(Socket, Opts, <<>>).
+
+loop(Socket, Opts, Buffer) ->
+    #{delay := Delay0} = Opts,
+    case gen_tcp:recv(Socket, 0) of
+        {ok, Data} ->
+            Split = binary:split(
+                <<Buffer/binary, Data/binary>>,
+                <<"\r\n\r\n">>,
+                [global]
+            ),
+            {N, Buffer2} = count_requests(Split, 0),
+            Responses = make_responses(N, Opts),
+            Ms =
+                case Delay0 of
+                    {rand, D} -> rand:uniform(D);
+                    _ -> Delay0
+                end,
+            Ms > 0 andalso delay(Socket, Ms),
+            case socket_send(Socket, Responses, Opts) of
+                ok ->
+                    case maps:get(oneoff, Opts, false) of
+                        true ->
+                            gen_tcp:shutdown(Socket, write),
+                            exit(normal);
+                        false ->
+                            ok
+                    end,
+                    loop(Socket, Opts, Buffer2);
+                {error, _Reason} ->
+                    ok
+            end;
+        {error, _Reason} ->
+            ok
+    end.
+
+delay(Socket, Timeout) ->
+    ?tp(?MODULE, #{pid => self(), delay => Timeout}),
+    receive
+        close_socket ->
+            gen_tcp:shutdown(Socket, write),
+            exit(normal)
+    after Timeout ->
+        ok
+    end.
+
+socket_send(_Socket, [], _Opts) ->
+    ok;
+socket_send(
+    Socket,
+    [
+        #{
+            headers := Headers,
+            body_chunks := BodyChunks
+        }
+        | Rest
+    ],
+    Opts
+) ->
+    ChunkedDelay =
+        case Opts of
+            #{chunked := #{delay := Delay}} ->
+                Delay;
+            _ ->
+                0
+        end,
+    case gen_tcp:send(Socket, Headers) of
+        ok ->
+            case socket_send_body_chunks(Socket, BodyChunks, ChunkedDelay) of
+                ok ->
+                    socket_send(Socket, Rest, Opts);
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+socket_send_body_chunks(_Socket, [], _) ->
+    ok;
+socket_send_body_chunks(Socket, [H | T], Delay) ->
+    case gen_tcp:send(Socket, H) of
+        ok ->
+            timer:sleep(Delay),
+            socket_send_body_chunks(Socket, T, Delay);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+make_responses(0, _Opts) ->
+    [];
+make_responses(N, Opts) ->
+    BodyChunks = make_body_chunks(Opts),
+    Headers = [
+        "HTTP/1.1 200 OK\r\n",
+        "Server: httpc_bench\r\n",
+        "Date: Tue, 07 Mar 2022 01:10:09 GMT\r\n",
+        "Content-Length: ",
+        integer_to_list(iolist_size(BodyChunks)),
+        "\r\n\r\n"
+    ],
+    [#{headers => Headers, body_chunks => BodyChunks} | make_responses(N - 1, Opts)].
+
+make_body_chunks(#{chunked := #{chunk_size := Size, chunks := Count}}) ->
+    [iolist_to_binary(lists:duplicate(Size, I)) || I <- lists:seq(1, Count)];
+make_body_chunks(_) ->
+    [iolist_to_binary(lists:duplicate(100, 0))].

--- a/test/ehttpc_test_lib.erl
+++ b/test/ehttpc_test_lib.erl
@@ -1,0 +1,112 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(ehttpc_test_lib).
+
+-export([
+    nolink_apply/1,
+    nolink_apply/2,
+    parallel_map/2
+]).
+
+%% @doc Delegate a function to a worker process.
+%% The function may spawn_link other processes but we do not
+%% want the caller process to be linked.
+%% This is done by isolating the possible link with a not-linked
+%% middleman process.
+nolink_apply(Fun) -> nolink_apply(Fun, infinity).
+
+%% @doc Same as `nolink_apply/1', with a timeout.
+-spec nolink_apply(function(), timer:timeout()) -> term().
+nolink_apply(Fun, Timeout) when is_function(Fun, 0) ->
+    Caller = self(),
+    ResRef = make_ref(),
+    Middleman = erlang:spawn(
+        fun() ->
+            process_flag(trap_exit, true),
+            CallerMRef = erlang:monitor(process, Caller),
+            Worker = erlang:spawn_link(
+                fun() ->
+                    Res =
+                        try
+                            {normal, Fun()}
+                        catch
+                            C:E:S -> {exception, {C, E, S}}
+                        end,
+                    _ = erlang:send(Caller, {ResRef, Res}),
+                    exit(normal)
+                end
+            ),
+            receive
+                {'DOWN', CallerMRef, process, _, _} ->
+                    %% For whatever reason, if the caller is dead,
+                    %% there is no reason to continue
+                    exit(Worker, kill),
+                    exit(normal);
+                {'EXIT', Worker, normal} ->
+                    exit(normal);
+                {'EXIT', Worker, Reason} ->
+                    %% worker has finished its job (Reason=normal)
+                    %% or might have crashed due to exception when evaluating Fun
+                    _ = erlang:send(Caller, {ResRef, {'EXIT', Reason}}),
+                    exit(normal)
+            end
+        end
+    ),
+    receive
+        {ResRef, {normal, Result}} ->
+            Result;
+        {ResRef, {exception, {C, E, S}}} ->
+            erlang:raise(C, E, S);
+        {ResRef, {'EXIT', Reason}} ->
+            exit(Reason)
+    after Timeout ->
+        exit(Middleman, kill),
+        exit(timeout)
+    end.
+
+%% @doc Like lists:map/2, only the callback function is evaluated
+%% concurrently.
+-spec parallel_map(function(), list()) -> list().
+parallel_map(Fun, List) ->
+    nolink_apply(fun() -> do_parallel_map(Fun, List) end).
+
+%%------------------------------------------------------------------------------
+%% Internal Functions
+%%------------------------------------------------------------------------------
+
+do_parallel_map(Fun, List) ->
+    Parent = self(),
+    PidList = lists:map(
+        fun(Item) ->
+            erlang:spawn_link(
+                fun() ->
+                    Parent ! {self(), Fun(Item)}
+                end
+            )
+        end,
+        List
+    ),
+    lists:foldr(
+        fun(Pid, Acc) ->
+            receive
+                {Pid, Result} ->
+                    [Result | Acc]
+            end
+        end,
+        [],
+        PidList
+    ).

--- a/test/ehttpc_tests.erl
+++ b/test/ehttpc_tests.erl
@@ -41,7 +41,8 @@ send_10_test_() ->
     PoolOpts1 = pool_opts(Port1, false),
     PoolOpts2 = pool_opts(Port2, false),
     [
-        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(10, 1000, 0)) end},
+        %% allow one retry for oneoff=true server, because of the 'DOWN' message race
+        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(10, 1000, 1)) end},
         {"oneoff=false", fun() -> ?WITH(ServerOpts2, PoolOpts2, req_sync(10)) end}
     ].
 
@@ -98,7 +99,8 @@ send_100_test_() ->
     PoolOpts1 = pool_opts(Port, false),
     PoolOpts2 = pool_opts(Port, true),
     [
-        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(100, 1000, 0)) end},
+        %% allow one retry for oneoff=true server, because of the 'DOWN' message race
+        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(100, 1000, 1)) end},
         {"oneoff=false", fun() -> ?WITH(ServerOpts2, PoolOpts2, req_async(100)) end}
     ].
 

--- a/test/ehttpc_tests.erl
+++ b/test/ehttpc_tests.erl
@@ -1,0 +1,491 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(ehttpc_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-define(POOL, ?MODULE).
+-define(PORT, (60000 + ?LINE)).
+
+-define(WITH_SERVER(Opts, Expr),
+    with_server(Opts, fun() -> Expr end)
+).
+-define(WITH_POOL(PoolOpts, Expr),
+    with_pool(PoolOpts, fun() -> Expr end)
+).
+
+-define(WITH(ServerOpts, PoolOpts, Expr),
+    ?WITH_SERVER(ServerOpts, ?WITH_POOL(PoolOpts, Expr))
+).
+
+send_10_test_() ->
+    Port1 = ?PORT,
+    Port2 = ?PORT,
+    ServerOpts1 = #{port => Port1, name => ?FUNCTION_NAME, delay => {rand, 300}, oneoff => true},
+    ServerOpts2 = #{port => Port2, name => ?FUNCTION_NAME, delay => {rand, 300}, oneoff => false},
+    PoolOpts1 = pool_opts(Port1, false),
+    PoolOpts2 = pool_opts(Port2, false),
+    [
+        %% one-off server closes socket after data send, so we need to retry
+        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(10, 1000, 1)) end},
+        {"oneoff=false", fun() -> ?WITH(ServerOpts2, PoolOpts2, req_sync(10)) end}
+    ].
+
+kill_gun_resume_test() ->
+    Port = ?PORT,
+    ServerOpts = #{port => Port, name => ?FUNCTION_NAME, delay => timer:seconds(30)},
+    PoolOpts = pool_opts(Port, false),
+    ?WITH(
+        ServerOpts,
+        PoolOpts,
+        begin
+            %% send a request and wait for it to timeout
+            Req1 = req(1),
+            Req2 = req(2),
+            {error, timeout} = ehttpc:request(?POOL, delete, Req1, 10, 0),
+            {ok, _} = ?block_until(#{?snk_kind := gun_up, req := Req1}, 1000, infinity),
+            {ok, _} = ?block_until(#{?snk_kind := shot, req := Req1}, 1000, infinity),
+            {_, #{client := Client}} = ehttpc:get_state(?POOL),
+            %% this call will be blocked
+            Tester = self(),
+            {Pid, MRef} = spawn_monitor(
+                fun() ->
+                    Tester ! ready,
+                    exit({return, ehttpc:request(?POOL, delete, Req2, 2_000, 0)})
+                end
+            ),
+            receive
+                ready -> ok
+            end,
+            timer:sleep(10),
+            {_, #{requests := Reqs}} = ehttpc:get_state(?POOL),
+            %% expect one sent, one pending
+            #{pending_count := 1, sent := Sent} = Reqs,
+            ?assertEqual(1, Sent),
+            %% kill the client
+            exit(Client, kill),
+            {ok, _} = ?block_until(#{?snk_kind := handle_client_down}, 1000, infinity),
+            {ok, _} = ?block_until(#{?snk_kind := gun_up, req := Req2}, 1000, infinity),
+            {ok, _} = ?block_until(#{?snk_kind := shot, req := Req2}, 1000, infinity),
+            {_, #{client := Client2}} = ehttpc:get_state(?POOL),
+            ?assert(erlang:is_process_alive(Client2)),
+            exit(Client2, kill),
+            receive
+                {'DOWN', MRef, process, Pid, Result} ->
+                    ?assertEqual({return, {error, killed}}, Result)
+            end
+        end
+    ).
+
+send_100_test_() ->
+    Port = ?PORT,
+    ServerOpts1 = #{port => Port, name => ?FUNCTION_NAME, delay => 3, oneoff => true},
+    ServerOpts2 = #{port => Port, name => ?FUNCTION_NAME, delay => {rand, 300}, oneoff => false},
+    PoolOpts1 = pool_opts(Port, false),
+    PoolOpts2 = pool_opts(Port, true),
+    [
+        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(100, 1000, 1)) end},
+        {"oneoff=false", fun() -> ?WITH(ServerOpts2, PoolOpts2, req_async(100)) end}
+    ].
+
+send_1000_test_() ->
+    TestTimeout = 30,
+    Port = ?PORT,
+    Opts1 = pool_opts(Port, true),
+    Opts2 = pool_opts(Port, false),
+    Opts3 = pool_opts("localhost", Port, true, true),
+    Opts4 = pool_opts("localhost", Port, false, true),
+    F = fun(Opts) ->
+        fun() ->
+            with_server(
+                Port,
+                ?FUNCTION_NAME,
+                0,
+                fun() ->
+                    with_pool(
+                        Opts,
+                        fun() -> req_async(1000, timer:seconds(TestTimeout)) end
+                    )
+                end
+            )
+        end
+    end,
+    [
+        {timeout, TestTimeout + 1, F(Opts1)},
+        {timeout, TestTimeout + 1, F(Opts2)},
+        {timeout, TestTimeout + 1, F(Opts3)},
+        {timeout, TestTimeout + 1, F(Opts4)}
+    ].
+
+requst_timeout_test_() ->
+    [
+        {"pipeline", fun() -> requst_timeout_test(true) end},
+        {"no pipeline", fun() -> requst_timeout_test(false) end}
+    ].
+
+requst_timeout_test(Pipeline) ->
+    Port = ?PORT,
+    with_server(
+        Port,
+        ?FUNCTION_NAME,
+        300_000,
+        fun() ->
+            with_pool(
+                pool_opts(Port, Pipeline),
+                fun() ->
+                    ?assertEqual(
+                        {error, timeout},
+                        req_sync_1(_Timeout = 1000)
+                    )
+                end
+            )
+        end
+    ).
+
+requst_expire_test() ->
+    Port = ?PORT,
+    with_server(
+        Port,
+        ?FUNCTION_NAME,
+        1_000,
+        fun() ->
+            with_pool(
+                pool_opts(Port, true),
+                fun() ->
+                    Pid = spawn(fun() -> req_sync_1(_Timeout = 10_000) end),
+                    {error, timeout} = req_sync_1(10),
+                    exit(Pid, kill),
+                    ok
+                end
+            )
+        end
+    ).
+
+server_outage_test_() ->
+    Port = ?PORT,
+    ServerName = ?FUNCTION_NAME,
+    ServerDelay = 300_000,
+    F =
+        fun() ->
+            %% ensure gun is connected to server
+            {error, timeout} = call(100),
+            %% now spawn a process which will never get a return value
+            {Pid, Ref} = spawn_monitor(fun() -> exit(call(100_000)) end),
+            {ok, _} = ?block_until(#{?snk_kind := shot}, 1000, infinity),
+            {ok, #{pid := ServerPid}} = ?block_until(
+                #{?snk_kind := ehttpc_server, delay := _}, 1000, infinity
+            ),
+            ServerPid ! close_socket,
+            Res =
+                receive
+                    {'DOWN', Ref, process, Pid, ExitReason} ->
+                        ExitReason
+                after 5_000 ->
+                    Worker = ehttpc_pool:pick_worker(?POOL),
+                    io:format(user, "~p\n", [sys:get_state(Worker)]),
+                    exit(timeout_waiting_for_gun_response)
+                end,
+            case Res of
+                {error, {shutdown, closed}} ->
+                    ok;
+                {error, {closed, _}} ->
+                    ok;
+                Other ->
+                    throw({unexpected_result, Other})
+            end
+        end,
+    [
+        {timeout, 20, fun() ->
+            with_server(
+                Port,
+                ServerName,
+                ServerDelay,
+                fun() -> with_pool(pool_opts(Port, true), F) end
+            )
+        end},
+        {timeout, 20, fun() ->
+            with_server(
+                Port,
+                ServerName,
+                ServerDelay,
+                fun() -> with_pool(pool_opts(Port, false), F) end
+            )
+        end}
+    ].
+
+%% c:l(ehttpc) should work for version 0.1.8 -> 0.1.15
+upgrade_state_on_the_fly_test() ->
+    Port = ?PORT,
+    ServerOpts = #{
+        port => Port,
+        name => ?FUNCTION_NAME,
+        %% no response during this test
+        delay => 300_000,
+        oneoff => false
+    },
+    PoolOpts = pool_opts("127.0.0.1", Port, _Pipelining = true, _PrioritiseLatest = false),
+    ?WITH(
+        ServerOpts,
+        PoolOpts,
+        begin
+            spawn_link(fun() -> ehttpc:request(?POOL, post, {<<"/">>, [], <<"test-post">>}) end),
+            {ok, _} = ?block_until(#{?snk_kind := shot}, 2000, infinity),
+            Pid = ehttpc_pool:pick_worker(?POOL),
+            GetState = fun() -> lists:reverse(tuple_to_list(sys:get_state(Pid))) end,
+            State = GetState(),
+            Requests = hd(State),
+            #{sent := Sent} = Requests,
+            ?assertEqual(1, maps:size(Sent)),
+            OldState = list_to_tuple(lists:reverse([Sent | tl(State)])),
+            %% put old format to the process state
+            sys:replace_state(Pid, fun(_) -> OldState end),
+            %% verify it's in the old format
+            ?assertEqual(Sent, hd(GetState())),
+            %% send a message to trigger upgrade
+            Pid ! dummy,
+            {error, _} = gen_server:call(Pid, dummy),
+            ok = gen_server:cast(Pid, dummy),
+            %% now it should be upgraded to the new version
+            ?assertMatch(#{sent := Sent}, hd(GetState())),
+            _ = sys:get_status(Pid),
+            ok
+        end
+    ).
+
+cool_down_after_5_reqs_test() ->
+    Port = ?PORT,
+    ServerOpts = #{
+        port => Port,
+        name => ?FUNCTION_NAME,
+        %% no response during this test
+        delay => 30_000,
+        oneoff => false
+    },
+    PoolOpts = pool_opts("127.0.0.1", Port, _Pipelining = 5, _PrioritiseLatest = false),
+    Reqs = [{"/", [], iolist_to_binary(["test-put-", integer_to_list(I)])} || I <- lists:seq(1, 6)],
+    ?WITH(
+        ServerOpts,
+        PoolOpts,
+        begin
+            lists:foreach(
+                fun(Req) ->
+                    spawn_link(fun() -> ehttpc:request(?POOL, put, {<<"/">>, [], Req}) end)
+                end,
+                Reqs
+            ),
+            {ok, _} = ?block_until(#{?snk_kind := cool_down}, 2000, infinity),
+            Pid = ehttpc_pool:pick_worker(?POOL),
+            #{requests := Requests} = ehttpc:get_state(Pid, normal),
+            #{sent := Sent, pending_count := PendingCount} = Requests,
+            ?assertEqual(5, maps:size(Sent)),
+            ?assertEqual(1, PendingCount),
+            ok
+        end
+    ).
+
+head_request_test() ->
+    Port = ?PORT,
+    Host = "127.0.0.1",
+    ?WITH(
+        #{
+            port => Port,
+            name => ?FUNCTION_NAME,
+            delay => 0
+        },
+        pool_opts(Host, Port, true),
+        {ok, _, _} = ehttpc:request(?POOL, head, <<"/">>)
+    ).
+
+data_chunked_test() ->
+    Port = ?PORT,
+    Host = "127.0.0.1",
+    ?WITH(
+        #{
+            port => Port,
+            name => ?FUNCTION_NAME,
+            delay => 0,
+            chunked => #{
+                delay => 10,
+                %% 10ms delay between chunked response body parts
+                chunk_size => 1 bsl 10,
+                chunks => 2
+            }
+        },
+        pool_opts(Host, Port, true),
+        begin
+            {ok, _, _, Body} = ehttpc:request(?POOL, get, req()),
+            ?assertEqual(1 bsl 11, size(Body)),
+            %% assert the order of the data
+            %% ehttpc_server generates chunks like 11111111111....
+            %% and 2222222.....
+            ?assertEqual([1, 2], dedup(binary_to_list(Body)))
+        end
+    ).
+
+data_chunk_timeout_test() ->
+    Port = ?PORT,
+    Host = "127.0.0.1",
+    ?WITH(
+        #{
+            port => Port,
+            name => ?FUNCTION_NAME,
+            delay => 0,
+            %% make the request
+            chunked => #{
+                delay => 10,
+                chunk_size => 4096,
+                chunks => 100
+            }
+        },
+        pool_opts(Host, Port, _Pipelining = 2),
+        ?assertEqual({error, timeout}, ehttpc:request(?POOL, get, req(), 200, 0))
+    ).
+
+connect_timeout_test() ->
+    Port = ?PORT,
+    Unreachable = "8.8.8.8",
+    ?WITH(
+        #{
+            port => Port,
+            name => ?FUNCTION_NAME,
+            delay => 0
+        },
+        pool_opts(Unreachable, Port, true),
+        ?assertEqual({error, connect_timeout}, req_sync_1(_Timeout = 200))
+    ).
+
+request_expire_test() ->
+    Port = ?PORT,
+    with_server(
+        #{
+            port => Port,
+            name => ?FUNCTION_NAME,
+            %% server delays one second before sending response
+            delay => timer:seconds(1)
+        },
+        fun() ->
+            with_pool(
+                pool_opts(Port, false),
+                fun() ->
+                    %% this call will be blocked, and timeout after 200ms
+                    spawn(fun() -> req_sync_1(200) end),
+                    %% this call will be blocked, and expire after 200ms
+                    ?assertEqual(
+                        {error, timeout},
+                        req_sync_1(_Timeout = 200)
+                    )
+                end
+            )
+        end
+    ).
+
+with_server(Port, Name, Delay, F) ->
+    Opts = #{port => Port, name => Name, delay => Delay},
+    with_server(Opts, F).
+
+with_server(Opts, F) ->
+    ?check_trace(
+        begin
+            Pid = ehttpc_server:start_link(Opts),
+            try
+                {ok, _} =
+                    ?block_until(
+                        #{
+                            ?snk_kind := ehttpc_server,
+                            state := accepting
+                        },
+                        2_000,
+                        infinity
+                    ),
+                F()
+            after
+                ehttpc_server:stop(Pid)
+            end
+        end,
+        []
+    ).
+
+req() -> {<<"/">>, [{<<"Connection">>, <<"Keep-Alive">>}]}.
+
+req(N) -> {iolist_to_binary(["/", integer_to_list(N)]), [{<<"Connection">>, <<"Keep-Alive">>}]}.
+
+req_sync_1(Timeout) ->
+    ehttpc:request(?POOL, get, req(), Timeout, 0).
+
+req_sync(N) ->
+    req_sync(N, 5_000, 0).
+
+req_sync(0, _Timeout, _Retry) ->
+    ok;
+req_sync(N, Timeout, Retry) ->
+    case ehttpc:request(?POOL, get, req(), Timeout, Retry) of
+        {ok, 200, _Headers, _Body} ->
+            req_sync(N - 1, Timeout, Retry);
+        {error, Reason} ->
+            error({N, Reason})
+    end.
+
+req_async(N) ->
+    req_async(N, 5_000).
+
+req_async(N, Timeout) ->
+    L = lists:seq(1, N),
+    ehttpc_test_lib:parallel_map(
+        fun(_) ->
+            req_sync(1, Timeout, 0)
+        end,
+        L
+    ).
+
+pool_opts(Port, Pipeline) ->
+    pool_opts("127.0.0.1", Port, Pipeline).
+
+pool_opts(Host, Port, Pipeline) ->
+    pool_opts(Host, Port, Pipeline, false).
+
+pool_opts(Host, Port, Pipeline, PrioLatest) ->
+    [
+        {host, Host},
+        {port, Port},
+        {enable_pipelining, Pipeline},
+        {pool_size, 1},
+        {pool_type, random},
+        {connect_timeout, 5000},
+        {retry, 0},
+        {retry_timeout, 1000},
+        {prioritise_latest, PrioLatest}
+    ].
+
+with_pool(Opts, F) ->
+    application:ensure_all_started(ehttpc),
+    try
+        {ok, _} = ehttpc_sup:start_pool(?POOL, Opts),
+        F()
+    after
+        ehttpc_sup:stop_pool(?POOL)
+    end.
+
+call(Timeout) ->
+    ehttpc:request(?POOL, get, req(), Timeout, 0).
+
+dedup(L) ->
+    dedup(hd(L), tl(L)).
+
+dedup(H, []) -> [H];
+dedup(H, [H | T]) -> dedup(H, T);
+dedup(H, [X | T]) -> [H | dedup(X, T)].


### PR DESCRIPTION
Major refactoring for performance gain.
Prior to this change, the ehttpc workers tend to accumulate long message queues
and the non-optimised `gun_xxx` message `receive` clauses becomes very much cpu intensive.

* collect calls in process state so the receives
  will not have to scan a potentially long mail box
  and the gun_xxx replies will not be queued behind the requests,
  allows the callers to get response sooner

* do not do stream_flush
  the stream cancellation is async, flushing it right
  after the cancellation will not prevent stale deliveries.
  In this refactoring, the unknown messages are silently discarded

* feat: add an option to prioritise latest requests.
  When `ehttpc` is queued with a lot of calls (especially when
  they expire quick and the latency towards http server is high),
  working on the head of the queue may get a lower chance of
  completing the request in time.
 Working on the rear however, will increase the chance.
  this is under the assumption that the calls are issued
  in a blocked fashion from individual caller processes.
  i.e. the order of the calls does not matter.

* refactor: generic handling for `enable_pipelining=true|false`.
  `enable_pipelining=true` means one can send infinite number of
  requests before receiving any responses,
  and `enable_pipelining=false` means only one request is allowed.
  What we need is just to check how many requests are allowed to be sent
  before response is received.
  The new implementation, we have:
  `true`: 100 (previously infinity)
  `false`: `1`
  `N`: now the `enable_pipelining` option can be an integer