### PR TITLE
fix: force kill after gradeful shutdown timeout

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ehttpc changes
 
+## 0.4.1
+
+* Avoid sending cancel stream messages if the stream is already finished
+* Force shutdown after 10 seconds
+
 ## 0.4.0
 
 * Add async APIs

--- a/changelog.md
+++ b/changelog.md
@@ -2,28 +2,28 @@
 
 ## 0.4.1
 
-* Avoid sending cancel stream messages if the stream is already finished
-* Force shutdown after 10 seconds
+- Avoid sending stream cancellation messages to the 'gun' process if the stream is already finished ('fin' received)
+- Force kill pool workers after 5 seconds waiting for graceful shutdown
 
 ## 0.4.0
 
-* Add async APIs
+- Add async APIs
 
 ## 0.3.0
 
-* Changes on top of 0.2.1:
+- Changes on top of 0.2.1:
 
   - Prohibit the `retry` and `retry_timeout` options.
 
 ## 0.2.1
 
-* Improvements and Bug Fixes
+- Improvements and Bug Fixes
 
   - Add ehttpc:health_check/2.
 
 ## 0.2.0
 
-* Major refactoring on top of 0.1.15
+- Major refactoring on top of 0.1.15
   - Added test cases.
   - Support hot upgrade from all 0.1.X versions.
   - No lower level retry (in 'gun' the http client lib).
@@ -34,3 +34,8 @@
   - Now all requests are async, so the `ehttpc:request` calls can be collected
     from mailbox into process state, this makes the handling of gun responses
     more effecient.
+
+## 0.1.14
+
+- fixed appup. old versions missed ehttpc_pool
+- added check_vsn.escript to sure version consistent and run in ci

--- a/changlog.md
+++ b/changlog.md
@@ -1,3 +1,0 @@
-* 0.1.14
-  - fixed appup. old versions missed ehttpc_pool
-  - added check_vsn.escript to sure version consistent and run in ci

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc,
  [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.4.0"},
+  {vsn, "0.4.1"},
   {registered, []},
   {applications, [kernel,
                   stdlib,

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,45 +1,77 @@
 %% -*-: erlang -*-
-{"0.4.0",
+{"0.4.1",
    [
-     {"0.3.0", [
-       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     {"0.4.0", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
-     {<<"0.2.[0-1]">>, [
-       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     {"0.3.0", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+     ]},
+     {<<"0\\.2\\.[0-1]">>, [
+       {load_module, ehttpc, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\\.[0-7]">>, [
        {update, ehttpc, {advanced, []}},
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.([8-9]|(1[0-4]))">>, [
        {update, ehttpc, {advanced, []}},
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {"0.1.15", [
-       {update, ehttpc, {advanced, []}}
+       {update, ehttpc, {advanced, []}},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]}
    ],
    [
-     {"0.3.0", [
-       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     {"0.4.0", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
-     {<<"0.2.[0-1]">>, [
-       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     {"0.3.0", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+     ]},
+     {<<"0\\.2\\.[0-1]">>, [
+       {load_module, ehttpc, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.0">>, [
        {update, ehttpc, {advanced, [no_requests]}},
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.[1-7]">>, [
        {update, ehttpc, {advanced, [no_enable_pipelining]}},
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.([8-9]|(1[0-4]))">>, [
        {update, ehttpc, {advanced, [downgrade_requests]}},
-       {load_module, ehttpc_pool, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]},
      {"0.1.15", [
-       {update, ehttpc, {advanced, [downgrade_requests]}}
+       {update, ehttpc, {advanced, [downgrade_requests]}},
+       {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
      ]}
    ]
 }.

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -566,6 +566,7 @@ drop_expired(#{pending := Pending, pending_count := PC} = Requests, Now) ->
             {_, NewPendings} = OutFun(Pending),
             NewRequests = Requests#{pending => NewPendings, pending_count => PC - 1},
             ok = maybe_reply_timeout(ReplyTo),
+            ?tp(?FUNCTION_NAME, #{}),
             drop_expired(NewRequests, Now);
         false ->
             Requests

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -220,6 +220,10 @@ handle_info(?ASYNC_REQ(Method, Request, ExpireAt, ResultCallback), State0) ->
     State1 = enqueue_req(ResultCallback, Req, upgrade_requests(State0)),
     State = maybe_shoot(State1),
     {noreply, State};
+handle_info({suspend, Time}, State) ->
+    %% only for testing
+    timer:sleep(Time),
+    {noreply, State};
 handle_info(Info, State0) ->
     State1 = do_handle_info(Info, upgrade_requests(State0)),
     State = maybe_shoot(State1),

--- a/src/ehttpc_pool_sup.erl
+++ b/src/ehttpc_pool_sup.erl
@@ -37,7 +37,7 @@ init([Pool, Opts]) ->
              #{id => worker_sup,
                start => {ehttpc_worker_sup, start_link, [Pool, Opts]},
                restart => transient,
-               shutdown => infinity,
+               shutdown => 5000,
                type => supervisor,
                modules => [ehttpc_worker_sup]}],
     {ok, {{one_for_all, 10, 100}, Specs}}.

--- a/src/ehttpc_sup.erl
+++ b/src/ehttpc_sup.erl
@@ -64,7 +64,7 @@ pool_spec(Pool, Opts) ->
     #{id => child_id(Pool),
       start => {ehttpc_pool_sup, start_link, [Pool, Opts]},
       restart => transient,
-      shutdown => infinity,
+      shutdown => 5000,
       type => supervisor,
       modules => [ehttpc_pool_sup]}.
 

--- a/test/ehttpc_server.erl
+++ b/test/ehttpc_server.erl
@@ -95,7 +95,7 @@ loop(Socket, Opts) ->
     loop(Socket, Opts, <<>>).
 
 loop(Socket, Opts, Buffer) ->
-    #{delay := Delay0} = Opts,
+    Delay0 = maps:get(delay, Opts, 0),
     case gen_tcp:recv(Socket, 0) of
         {ok, Data} ->
             Split = binary:split(
@@ -158,9 +158,16 @@ socket_send(
             _ ->
                 0
         end,
+    FinDelay =
+        case Opts of
+            #{chunked := #{fin_delay := Fd}} ->
+                Fd;
+            _ ->
+                0
+        end,
     case gen_tcp:send(Socket, Headers) of
         ok ->
-            case socket_send_body_chunks(Socket, BodyChunks, ChunkedDelay) of
+            case socket_send_body_chunks(Socket, BodyChunks, ChunkedDelay, FinDelay) of
                 ok ->
                     socket_send(Socket, Rest, Opts);
                 {error, Reason} ->
@@ -170,13 +177,19 @@ socket_send(
             {error, Reason}
     end.
 
-socket_send_body_chunks(_Socket, [], _) ->
+socket_send_body_chunks(_Socket, [], _, _) ->
     ok;
-socket_send_body_chunks(Socket, [H | T], Delay) ->
+socket_send_body_chunks(Socket, [H | T], Delay, FinDelay) ->
     case gen_tcp:send(Socket, H) of
         ok ->
             timer:sleep(Delay),
-            socket_send_body_chunks(Socket, T, Delay);
+            case T =:= [] of
+                true ->
+                    timer:sleep(FinDelay);
+                false ->
+                    ok
+            end,
+            socket_send_body_chunks(Socket, T, Delay, FinDelay);
         {error, Reason} ->
             {error, Reason}
     end.
@@ -184,18 +197,28 @@ socket_send_body_chunks(Socket, [H | T], Delay) ->
 make_responses(0, _Opts) ->
     [];
 make_responses(N, Opts) ->
-    BodyChunks = make_body_chunks(Opts),
-    Headers = [
-        "HTTP/1.1 200 OK\r\n",
-        "Server: httpc_bench\r\n",
-        "Date: Tue, 07 Mar 2022 01:10:09 GMT\r\n",
-        "Content-Length: ",
-        integer_to_list(iolist_size(BodyChunks)),
-        "\r\n\r\n"
-    ],
-    [#{headers => Headers, body_chunks => BodyChunks} | make_responses(N - 1, Opts)].
+    Headers0 =
+        [ "HTTP/1.1 200 OK\r\n",
+          "Server: ehttpc_test_server\r\n",
+          "Date: Tue, 07 Mar 2022 01:10:09 GMT\r\n"
+        ],
+    {MoreHeaders, BodyChunks} =
+        case Opts of
+            #{chunked := _} ->
+                {["Transfer-Encoding: chunked", "\r\n", "\r\n"], make_chunks(Opts)};
+            _ ->
+                Body = iolist_to_binary(lists:duplicate(100, 0)),
+                Len = integer_to_list(iolist_size(Body)),
+                {["Content-Length: ", Len, "\r\n", "\r\n"], [Body]}
+        end,
+    Headers = Headers0 ++ MoreHeaders,
+    Resp = #{headers => Headers,
+             body_chunks => BodyChunks
+            },
+    [Resp | make_responses(N - 1, Opts)].
 
-make_body_chunks(#{chunked := #{chunk_size := Size, chunks := Count}}) ->
-    [iolist_to_binary(lists:duplicate(Size, I)) || I <- lists:seq(1, Count)];
-make_body_chunks(_) ->
-    [iolist_to_binary(lists:duplicate(100, 0))].
+make_chunks(#{chunked := #{chunk_size := Size, chunks := Count}}) ->
+    %% we use the counts to generat bytes, (to verify the final number of chunks received)
+    Count > 255 andalso error({bad_chunk_count, Count}),
+    RawL = [iolist_to_binary(lists:duplicate(Size, I)) || I <- lists:seq(1, Count)],
+    [cow_http_te:chunk(I) || I <- RawL] ++ [cow_http_te:last_chunk()].

--- a/test/ehttpc_server.erl
+++ b/test/ehttpc_server.erl
@@ -199,9 +199,10 @@ make_responses(0, _Opts) ->
     [];
 make_responses(N, Opts) ->
     Headers0 =
-        [ "HTTP/1.1 200 OK\r\n",
-          "Server: ehttpc_test_server\r\n",
-          "Date: Tue, 07 Mar 2022 01:10:09 GMT\r\n"
+        [
+            "HTTP/1.1 200 OK\r\n",
+            "Server: ehttpc_test_server\r\n",
+            "Date: Tue, 07 Mar 2022 01:10:09 GMT\r\n"
         ],
     {MoreHeaders, BodyChunks} =
         case Opts of
@@ -213,9 +214,10 @@ make_responses(N, Opts) ->
                 {["Content-Length: ", Len, "\r\n", "\r\n"], [Body]}
         end,
     Headers = Headers0 ++ MoreHeaders,
-    Resp = #{headers => Headers,
-             body_chunks => BodyChunks
-            },
+    Resp = #{
+        headers => Headers,
+        body_chunks => BodyChunks
+    },
     [Resp | make_responses(N - 1, Opts)].
 
 make_chunks(#{chunked := #{chunk_size := Size, chunks := Count}}) ->

--- a/test/ehttpc_sup_tests.erl
+++ b/test/ehttpc_sup_tests.erl
@@ -1,0 +1,67 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(ehttpc_sup_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(POOL, ?MODULE).
+
+
+shutdown_test_() ->
+    [ {timeout, 10, fun t_shutdown/0}
+    ].
+
+t_shutdown() ->
+    Opts = [ {host, "google.com"},
+             {port, "80"},
+             {enable_pipelining, 1},
+             {pool_size, 1},
+             {pool_type, random},
+             {connect_timeout, 5000},
+             {prioritise_latest, true}
+           ],
+    application:ensure_all_started(ehttpc),
+    {ok, SupPid} = ehttpc_sup:start_pool(?POOL, Opts),
+    unlink(SupPid),
+    _ = monitor(process, SupPid),
+    try
+        Worker = ehttpc_pool:pick_worker(?POOL),
+        _ = monitor(process, Worker),
+        _ = sys:get_state(Worker),
+        %% suspend (zombie-fy) the (one and only) worker
+        Worker ! {suspend, timer:seconds(60)},
+        %% zombie worker should not block pool stop
+        ok = ehttpc_sup:stop_pool(?POOL),
+        receive
+            {'DOWN', _, process, SupPid, killed} ->
+                ok;
+            Other2 ->
+                ct:fail({"unexpected_message", Other2})
+        after 6000 ->
+                  ct:fail("failed_to_stop_pool_supervisor")
+        end,
+        receive
+            {'DOWN', _, process, Worker, killed} ->
+                ok;
+            Other ->
+                ct:fail({"unexpected_message", Other})
+        after 1000 ->
+                  ct:fail("failed_to_stop_worker_from_sup_shutdown")
+        end
+    after
+        exit(SupPid, kill)
+    end.

--- a/test/ehttpc_test_lib.erl
+++ b/test/ehttpc_test_lib.erl
@@ -21,6 +21,7 @@
     nolink_apply/2,
     parallel_map/2,
     with_server/2,
+    with_server/3,
     with_server/4,
     with_pool/3,
     pool_opts/2,
@@ -123,6 +124,9 @@ with_server(Port, Name, Delay, F) ->
     with_server(Opts, F).
 
 with_server(Opts, F) ->
+    with_server(Opts, F, _CheckTrace = fun(_, _) -> ok end).
+
+with_server(Opts, F, CheckTrace) ->
     ?check_trace(
         begin
             Pid = ehttpc_server:start_link(Opts),
@@ -141,7 +145,7 @@ with_server(Opts, F) ->
                 ehttpc_server:stop(Pid)
             end
         end,
-        []
+        CheckTrace
     ).
 
 %%------------------------------------------------------------------------------

--- a/test/ehttpc_tests.erl
+++ b/test/ehttpc_tests.erl
@@ -560,8 +560,8 @@ request_expire_fin_too_late_test() ->
             )
         end,
         fun(_, Trace) ->
-                %% assert one request dropped directly
-                ?assertMatch([_], ?of_kind(drop_expired, Trace))
+            %% assert one request dropped directly
+            ?assertMatch([_], ?of_kind(drop_expired, Trace))
         end
     ).
 


### PR DESCRIPTION
- Force kill pool workers after 5 seconds waiting for graceful shutdown
- Avoid sending stream cancellation messages to the 'gun' process if the stream is already finished ('fin' received)
