### PR TITLE
chore: support blessed `format_status/1` callback

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -10,17 +10,25 @@ jobs:
 
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
-    container:
-      image: "ghcr.io/emqx/emqx-builder/5.0:24.1.1-emqx-1-ubuntu20.04"
+    strategy:
+      fail-fast: false
+      matrix:
+        otp:
+          - 24.3
+          - 25.1
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
-        fetch-depth: 1000
+        fetch-depth: 0
     - name: Fetch tags
       run: git fetch --tags
+    - uses: erlef/setup-beam@v1
+      with:
+        otp-version: ${{ matrix.otp }}
+        rebar3-version: 3
     - name: Compile
       run: rebar3 compile
     - name: Run tests

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ehttpc changes
 
+## 0.4.3
+
+- Update `gproc` dependency to 0.9.0.
+- Add `format_status/1` for OTP 25.
+
 ## 0.4.2
 
 - Do not crash on `retry` and `retry_timeout` options.

--- a/rebar.config
+++ b/rebar.config
@@ -2,8 +2,8 @@
 
 {deps, [
     {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
-    {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}},
-    {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.18.0"}}}
+    {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.9.0"}}},
+    {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.3"}}}
 ]}.
 
 {erl_opts, [

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc,
  [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.4.2"},
+  {vsn, "0.4.3"},
   {registered, []},
   {applications, [kernel,
                   stdlib,

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,6 +1,9 @@
 %% -*-: erlang -*-
-{"0.4.2",
+{"0.4.3",
    [
+     {"0.4.2", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     ]},
      {"0.4.1", [
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
@@ -38,6 +41,9 @@
      ]}
    ],
    [
+     {"0.4.2", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     ]},
      {"0.4.1", [
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -38,6 +38,7 @@
     handle_info/2,
     terminate/2,
     code_change/3,
+    format_status/1,
     format_status/2,
     format_state/2
 ]).
@@ -352,6 +353,12 @@ code_change(_Vsn, State, _) ->
     %% upgrade from a version ahving old format 'requests' field
     {ok, upgrade_requests(State)}.
 
+format_status(Status = #{state := State}) ->
+    Status#{state => format_state(State, minimal)}.
+
+%% TODO
+%% This is deprecated since OTP-25 in favor of `format_status/1`. Remove once
+%% OTP-25 becomes minimum supported OTP version.
 format_status(_Opt, [_PDict, State]) ->
     format_state(State, minimal).
 

--- a/test/ehttpc_async_tests.erl
+++ b/test/ehttpc_async_tests.erl
@@ -41,7 +41,6 @@ send_10_sync_test_() ->
     PoolOpts1 = pool_opts(Port1, false),
     PoolOpts2 = pool_opts(Port2, false),
     [
-        %% allow one retry for oneoff=true server, because of the 'DOWN' message race
         {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(10, 1000)) end},
         {"oneoff=false", fun() -> ?WITH(ServerOpts2, PoolOpts2, req_sync(10)) end}
     ].

--- a/test/ehttpc_async_tests.erl
+++ b/test/ehttpc_async_tests.erl
@@ -34,16 +34,10 @@
 ).
 
 send_10_sync_test_() ->
-    Port1 = ?PORT,
-    Port2 = ?PORT,
-    ServerOpts1 = #{port => Port1, name => ?FUNCTION_NAME, delay => {rand, 300}, oneoff => true},
-    ServerOpts2 = #{port => Port2, name => ?FUNCTION_NAME, delay => {rand, 300}, oneoff => false},
-    PoolOpts1 = pool_opts(Port1, false),
-    PoolOpts2 = pool_opts(Port2, false),
-    [
-        {"oneoff=true", fun() -> ?WITH(ServerOpts1, PoolOpts1, req_sync(10, 1000)) end},
-        {"oneoff=false", fun() -> ?WITH(ServerOpts2, PoolOpts2, req_sync(10)) end}
-    ].
+    Port = ?PORT,
+    ServerOpts = #{port => Port, name => ?FUNCTION_NAME, delay => {rand, 300}, oneoff => false},
+    PoolOpts = pool_opts(Port, false),
+    {"oneoff=false", fun() -> ?WITH(ServerOpts, PoolOpts, req_sync(10)) end}.
 
 send_10_async_test() ->
     Port = ?PORT,

--- a/test/ehttpc_async_tests.erl
+++ b/test/ehttpc_async_tests.erl
@@ -63,7 +63,7 @@ no_expired_req_send_test() ->
             %% ensure all the requests are queued
             ok = ehttpc:health_check(Pid, 100),
             %% send another one after a delay, this will trigger ehttpc worker to drop all expired requests and reply {error, timeout}
-            timer:sleep(TimeoutMs),
+            timer:sleep(TimeoutMs * 2),
             [_] = send_reqs(1, TimeoutMs + 10),
             lists:foreach(
                 fun(Ref) ->


### PR DESCRIPTION
Also mention that `format_status/2` callback is deprecated since OTP-25.

---

[EMQX-8562](https://emqx.atlassian.net/browse/EMQX-8562)