### PR TITLE
0124 pool can be any

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ehttpc changes
 
+## 0.4.5
+
+- Make possible to start pool with `any()` name (not limited to `atom()`).
+
 ## 0.4.4
 
 - Fix the issue that ehttpc opens a new client when an existing client has been

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc,
  [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.4.4"},
+  {vsn, "0.4.5"},
   {registered, []},
   {applications, [kernel,
                   stdlib,

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,83 +1,90 @@
 %% -*-: erlang -*-
-{"0.4.4",
+{"0.4.5",
    [
-     {<<"0\\.4\\.[1-3]">>, [
-       {load_module, ehttpc, brutal_purge, soft_purge, []}
-     ]},
-     {"0.4.0", [
+     {<<"0\\.4\\.[0-4]">>, [
        {load_module, ehttpc, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {"0.3.0", [
        {load_module, ehttpc, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.2\\.[0-1]">>, [
        {load_module, ehttpc, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\\.[0-7]">>, [
        {update, ehttpc, {advanced, []}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.([8-9]|(1[0-4]))">>, [
        {update, ehttpc, {advanced, []}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {"0.1.15", [
        {update, ehttpc, {advanced, []}},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]}
    ],
    [
-     {<<"0\\.4\\.[1-3]">>, [
-       {load_module, ehttpc, brutal_purge, soft_purge, []}
-     ]},
-     {"0.4.0", [
+     {<<"0\\.4\\.[0-4]">>, [
        {load_module, ehttpc, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {"0.3.0", [
        {load_module, ehttpc, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.2\\.[0-1]">>, [
        {load_module, ehttpc, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.0">>, [
        {update, ehttpc, {advanced, [no_requests]}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.[1-7]">>, [
        {update, ehttpc, {advanced, [no_enable_pipelining]}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.1\\.([8-9]|(1[0-4]))">>, [
        {update, ehttpc, {advanced, [downgrade_requests]}},
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]},
      {"0.1.15", [
        {update, ehttpc, {advanced, [downgrade_requests]}},
        {load_module, ehttpc_sup, brutal_purge, soft_purge, []},
-       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []}
+       {load_module, ehttpc_pool_sup, brutal_purge, soft_purge, []},
+       {load_module, ehttpc_worker_sup, brutal_purge, soft_purge, []}
      ]}
    ]
 }.

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -77,6 +77,7 @@
 ).
 -define(GEN_CALL_REQ(From, Call), {'$gen_call', From, ?REQ(_, _, _) = Call}).
 -define(undef, undefined).
+-define(IS_POOL(Pool), (not is_pid(Pool))).
 
 -record(state, {
     pool :: term(),
@@ -91,7 +92,7 @@
     requests :: map()
 }).
 
--type pool_name() :: atom().
+-type pool_name() :: any().
 -type option() :: [{atom(), term()}].
 
 %%--------------------------------------------------------------------
@@ -103,7 +104,7 @@ get_state(PoolOrWorker) ->
     get_state(PoolOrWorker, minimal).
 
 %% @doc For test, debug and troubleshooting.
-get_state(Pool, Style) when is_atom(Pool) ->
+get_state(Pool, Style) when ?IS_POOL(Pool) ->
     Worker = ehttpc_pool:pick_worker(Pool),
     {Worker, get_state(Worker, Style)};
 get_state(Worker, Style) when is_pid(Worker) ->
@@ -131,9 +132,9 @@ request(Pool, Method, Request) ->
 request(Pool, Method, Request, Timeout) ->
     request(Pool, Method, Request, Timeout, 2).
 
-request(Pool, Method, Request, Timeout, Retry) when is_atom(Pool) ->
+request(Pool, Method, Request, Timeout, Retry) when ?IS_POOL(Pool) ->
     request(ehttpc_pool:pick_worker(Pool), Method, Request, Timeout, Retry);
-request({Pool, N}, Method, Request, Timeout, Retry) when is_atom(Pool) ->
+request({Pool, N}, Method, Request, Timeout, Retry) when ?IS_POOL(Pool) ->
     request(ehttpc_pool:pick_worker(Pool, N), Method, Request, Timeout, Retry);
 request(Worker, Method, Request, Timeout, Retry) when is_pid(Worker) ->
     ExpireAt = now_() + Timeout,

--- a/src/ehttpc_pool.erl
+++ b/src/ehttpc_pool.erl
@@ -53,10 +53,10 @@ start_link(Pool, Opts) ->
 info(Pid) ->
     gen_server:call(Pid, info).
 
-start_pool(Pool, Opts) when is_atom(Pool) ->
+start_pool(Pool, Opts) ->
     ehttpc_sup:start_pool(Pool, Opts).
 
-stop_pool(Pool) when is_atom(Pool) ->
+stop_pool(Pool) ->
     ehttpc_sup:stop_pool(Pool).
 
 pick_worker(Pool) ->

--- a/src/ehttpc_sup.erl
+++ b/src/ehttpc_sup.erl
@@ -29,7 +29,7 @@
 -export([init/1]).
 
 %% @doc Start supervisor.
--spec(start_link() -> {ok, pid()} | {error, term()}).
+-spec start_link() -> {ok, pid()} | {error, term()}.
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
@@ -38,19 +38,19 @@ start_link() ->
 %%--------------------------------------------------------------------
 
 %% @doc Start a pool.
--spec(start_pool(atom(), list(tuple())) -> {ok, pid()} | {error, term()}).
-start_pool(Pool, Opts) when is_atom(Pool) ->
+-spec start_pool(ehttpc:pool_name(), list(tuple())) -> {ok, pid()} | {error, term()}.
+start_pool(Pool, Opts) ->
     supervisor:start_child(?MODULE, pool_spec(Pool, Opts)).
 
 %% @doc Stop a pool.
--spec(stop_pool(Pool :: atom()) -> ok | {error, term()}).
-stop_pool(Pool) when is_atom(Pool) ->
+-spec stop_pool(Pool :: ehttpc:pool_name()) -> ok | {error, term()}.
+stop_pool(Pool) ->
     ChildId = child_id(Pool),
 	case supervisor:terminate_child(?MODULE, ChildId) of
         ok ->
             supervisor:delete_child(?MODULE, ChildId);
-        {error, Reason} ->
-            {error, Reason}
+        {error, not_found} ->
+            ok
 	end.
 
 %%--------------------------------------------------------------------
@@ -69,4 +69,3 @@ pool_spec(Pool, Opts) ->
       modules => [ehttpc_pool_sup]}.
 
 child_id(Pool) -> {ehttpc_pool_sup, Pool}.
-

--- a/src/ehttpc_worker_sup.erl
+++ b/src/ehttpc_worker_sup.erl
@@ -22,7 +22,7 @@
 
 -export([init/1]).
 
-start_link(Pool, Opts) when is_atom(Pool) ->
+start_link(Pool, Opts) ->
     supervisor:start_link(?MODULE, [Pool, Opts]).
 
 init([Pool, Opts]) ->

--- a/test/ehttpc_tests.erl
+++ b/test/ehttpc_tests.erl
@@ -19,7 +19,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--define(POOL, ?MODULE).
+-define(POOL, <<"testpool">>).
 -define(PORT, (60000 + ?LINE)).
 
 -define(WITH_SERVER(Opts, Expr),


### PR DESCRIPTION
the unnecessary constraint of pool name must be `atom()` imposes atom leak.