### PR TITLE
fix: crash and no message send with body headers and no body

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ehttpc changes
 
+## 0.4.7
+
+- Fix crash when using body headers and no body. When one sent a message with, for example, the content-type header and no body, the underlying gun library would expect a body to come with a gun:data/3 call and would not finish the request. The next request would then crash. See the following issue for more information: https://github.com/ninenines/gun/issues/141
+
 ## 0.4.6
 
 - Fix a bug introduced in 0.4.5: `badarg` crash from `grpoc` when `pool_type` is `hash`.

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc,
  [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.4.6"},
+  {vsn, "0.4.7"},
   {registered, []},
   {applications, [kernel,
                   stdlib,

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,6 +1,9 @@
 %% -*-: erlang -*-
-{"0.4.6",
+{"0.4.7",
    [
+     {"0.4.6", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     ]},
      {"0.4.5", [
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
@@ -44,6 +47,9 @@
      ]}
    ],
    [
+     {"0.4.6", [
+       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     ]},
      {"0.4.5", [
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -494,10 +494,9 @@ finish_body_call_if_needed(Client, RequestRef, Headers, Body) ->
     case is_finish_body_call_needed(Headers, Body) of
         true ->
             gun:data(Client, RequestRef, fin, <<>>);
-        false -> 
+        false ->
             ok
     end.
-
 
 %% The following function corresponds to request_io_from_headers from
 %% src/gun_http.erl https://github.com/ninenines/gun commit id
@@ -525,7 +524,7 @@ is_finish_body_call_needed(_Headers, _NotEmptyBin) ->
 is_content_type_field_set(Headers) ->
     case lists:keymember(<<"content-type">>, 1, Headers) of
         true -> true;
-        false ->false 
+        false -> false
     end.
 
 cancel_stream(fin, _Client, _StreamRef) ->

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -522,10 +522,7 @@ is_finish_body_call_needed(_Headers, _NotEmptyBin) ->
     false.
 
 is_content_type_field_set(Headers) ->
-    case lists:keymember(<<"content-type">>, 1, Headers) of
-        true -> true;
-        false -> false
-    end.
+    lists:keymember(<<"content-type">>, 1, Headers).
 
 cancel_stream(fin, _Client, _StreamRef) ->
     %% nothing to cancel anyway

--- a/test/ehttpc_server.erl
+++ b/test/ehttpc_server.erl
@@ -101,6 +101,7 @@ loop(fetch_header, Socket, Opts, Buffer) ->
             Data1 = <<Buffer/binary, Data0/binary>>,
             loop(check_header_and_continue_fetch_if_not_ready, Socket, Opts, Data1);
         {error, _Reason} ->
+            %% socket closed ? stop looping
             ok
     end;
 loop(parse_header, Socket, Opts, Buffer) ->
@@ -143,6 +144,7 @@ loop_send_response(Socket, Opts, Buffer, IsHead) ->
             end,
             loop(check_header_and_continue_fetch_if_not_ready, Socket, Opts, Buffer);
         {error, _Reason} ->
+            %% socket closed ? stop looping
             ok
     end.
 

--- a/test/ehttpc_server.erl
+++ b/test/ehttpc_server.erl
@@ -86,12 +86,11 @@ listen(Port) ->
 loop(Socket, Opts) ->
     loop(fetch_header, Socket, Opts, <<>>).
 
-
 loop(check_header_and_continue_fetch_if_not_ready, Socket, Opts, Buffer) ->
     case string:find(Buffer, <<"\r\n\r\n">>) of
-        nomatch -> 
+        nomatch ->
             loop(fetch_header, Socket, Opts, Buffer);
-        _Match -> 
+        _Match ->
             loop(parse_header, Socket, Opts, Buffer)
     end;
 loop(fetch_header, Socket, Opts, Buffer) ->
@@ -106,7 +105,7 @@ loop(fetch_header, Socket, Opts, Buffer) ->
     end;
 loop(parse_header, Socket, Opts, Buffer) ->
     [Header | Rest] =
-         binary:split(Buffer, <<"\r\n\r\n">>, []),
+        binary:split(Buffer, <<"\r\n\r\n">>, []),
     NewBuffer =
         case re:run(Header, <<"transfer-encoding:.*chunked">>, [caseless]) of
             nomatch ->
@@ -115,7 +114,7 @@ loop(parse_header, Socket, Opts, Buffer) ->
             _ ->
                 read_chunked_body(Socket, iolist_to_binary(Rest))
         end,
-    IsHead = 
+    IsHead =
         case re:run(Header, <<"^HEAD ">>, [caseless]) of
             nomatch ->
                 false;
@@ -149,14 +148,14 @@ loop_send_response(Socket, Opts, Buffer, IsHead) ->
 
 get_body_length(Header) ->
     case re:run(Header, <<"content-length:.*(\\d+)">>, [caseless]) of
-        nomatch -> 0;
-        {match,[_,{Pos,Len}|_]} ->
-            binary_to_integer(iolist_to_binary(string:substr(binary_to_list(Header), Pos+1,Len)))
+        nomatch ->
+            0;
+        {match, [_, {Pos, Len} | _]} ->
+            binary_to_integer(iolist_to_binary(string:substr(binary_to_list(Header), Pos + 1, Len)))
     end.
 
-
-read_normal_body(_Socket, Buffer, BytesLeftToRead)  when size(Buffer) >= BytesLeftToRead ->
-    <<_:BytesLeftToRead/binary,Rest/binary>> = Buffer,
+read_normal_body(_Socket, Buffer, BytesLeftToRead) when size(Buffer) >= BytesLeftToRead ->
+    <<_:BytesLeftToRead/binary, Rest/binary>> = Buffer,
     Rest;
 read_normal_body(Socket, Buffer, BytesLeftToRead) ->
     case gen_tcp:recv(Socket, 0) of
@@ -176,7 +175,7 @@ read_chunked_body(Socket, Buffer) ->
                     NewBuffer = <<Buffer/binary, Data/binary>>,
                     read_chunked_body(Socket, NewBuffer)
             end;
-        RemainingPlusLastChunk -> 
+        RemainingPlusLastChunk ->
             iolist_to_binary(string:slice(RemainingPlusLastChunk, string:length(LastChunk)))
     end.
 
@@ -192,10 +191,10 @@ delay(Socket, Timeout) ->
 
 socket_send(
     Socket,
-        #{
-            headers := Headers,
-            body_chunks := BodyChunks
-        },
+    #{
+        headers := Headers,
+        body_chunks := BodyChunks
+    },
     Opts
 ) ->
     ChunkedDelay =
@@ -260,7 +259,7 @@ make_response(Opts, IsHead) ->
                     end,
                 {["Transfer-Encoding: chunked", "\r\n", "\r\n"], Chunks};
             _ ->
-                Body = 
+                Body =
                     case IsHead of
                         true -> [];
                         false -> [iolist_to_binary(lists:duplicate(100, 0))]

--- a/test/ehttpc_tests.erl
+++ b/test/ehttpc_tests.erl
@@ -699,55 +699,67 @@ dedup(H, [X | T]) -> [H | dedup(X, T)].
 no_body_but_headers_indicating_body_test_() ->
     snabbkaffe:fix_ct_logging(),
     Port = ?PORT,
-    ServerOpts = #{port => Port, name => ?FUNCTION_NAME,  oneoff => false},
+    ServerOpts = #{port => Port, name => ?FUNCTION_NAME, oneoff => false},
     PoolOpts = pool_opts(Port, false),
     RequestsWithBody =
         fun() ->
-                [begin
-                     Response1 = ehttpc:request(?POOL,
-                                                RequestType,
-                                                {<<"/">>, [{<<"content-type">>, <<"text/html">>}], <<>>},
-                                                5000,
-                                                0),
-                     ok = ensure_not_error_response(Response1),
-                     Response2 = ehttpc:request(?POOL,
-                                                RequestType,
-                                                {<<"/">>, [{<<"content-length">>, <<"0">>}], <<>>},
-                                                5000,
-                                                0),
-                     ok = ensure_not_error_response(Response2)
-                 end ||
-                 RequestType <- [put, post]]
+            [
+                begin
+                    Response1 = ehttpc:request(
+                        ?POOL,
+                        RequestType,
+                        {<<"/">>, [{<<"content-type">>, <<"text/html">>}], <<>>},
+                        5000,
+                        0
+                    ),
+                    ok = ensure_not_error_response(Response1),
+                    Response2 = ehttpc:request(
+                        ?POOL,
+                        RequestType,
+                        {<<"/">>, [{<<"content-length">>, <<"0">>}], <<>>},
+                        5000,
+                        0
+                    ),
+                    ok = ensure_not_error_response(Response2)
+                end
+             || RequestType <- [put, post]
+            ]
         end,
     RequestsWithNoBody =
         fun() ->
-            [begin 
-                 Response1 = ehttpc:request(?POOL,
-                                            RequestType,
-                                            {<<"/">>, [{<<"content-type">>, <<"text/html">>}]},
-                                            5000,
-                                            0),
-                 ok = ensure_not_error_response(Response1),
-                 Response2 = ehttpc:request(?POOL,
-                                            RequestType,
-                                            {<<"/">>, [{<<"content-length">>, <<"0">>}]},
-                                            5000,
-                                            0),
-                 ok = ensure_not_error_response(Response2)
-             end ||
-             %% Extra get inthe end so all requests have a request comming after them.
-            RequestType <- [get, delete, head, get]]
+            [
+                begin
+                    Response1 = ehttpc:request(
+                        ?POOL,
+                        RequestType,
+                        {<<"/">>, [{<<"content-type">>, <<"text/html">>}]},
+                        5000,
+                        0
+                    ),
+                    ok = ensure_not_error_response(Response1),
+                    Response2 = ehttpc:request(
+                        ?POOL,
+                        RequestType,
+                        {<<"/">>, [{<<"content-length">>, <<"0">>}]},
+                        5000,
+                        0
+                    ),
+                    ok = ensure_not_error_response(Response2)
+                end
+             || %% Extra get inthe end so all requests have a request comming after them.
+                RequestType <- [get, delete, head, get]
+            ]
         end,
-    TestFunction = 
+    TestFunction =
         fun() ->
-                RequestsWithBody(),
-                RequestsWithNoBody()
+            RequestsWithBody(),
+            RequestsWithNoBody()
         end,
     [
         fun() -> ?WITH(ServerOpts, PoolOpts, TestFunction()) end
     ].
 
 ensure_not_error_response({error, _Reason} = Error) ->
-    Error; 
+    Error;
 ensure_not_error_response(_) ->
     ok.


### PR DESCRIPTION
When one sent a message with, for example, the content-type header and no body, the underlying gun library would expect a body to come with a gun:data/3 call and would not finish the request. The next request would then crash. See the following issue for more information:

https://github.com/ninenines/gun/issues/141

To write regression testcases for this issue, I also had to make changes to the test server so that it would handle the content type content-length.

Fixes:
https://emqx.atlassian.net/browse/EMQX-8980