### PR TITLE
fix: retry requests when `normal` race condition error is received

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,8 +1,10 @@
+%% -*- mode: erlang; -*-
+
 {minimum_otp_vsn, "21.0"}.
 
 {deps, [
     {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
-    {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
+    {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.9.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.7"}}}
 ]}.
 


### PR DESCRIPTION
During performance tests, we observed that some requests would also
occasionally fail with `{shutdown, normal}`, similar to the `normal`
race condition errors.

Also during those tests, we observed that the health check call would
also fail with reason `normal`, which brings the whole bridge in EMQX
5.0 to a grinding halt.
