### PR TITLE
feat: start-link gun process

### DIFF
--- a/.github/workflows/erlang.yml
+++ b/.github/workflows/erlang.yml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         otp:
-          - 24.3
-          - 25.1
+          - 26.1
+          - 25.3
 
     steps:
     - uses: actions/checkout@v3

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # ehttpc changes
 
+## 0.4.12
+
+- Upgrade to gun 1.3.10 (OTP 26)
+- Changed from `gun:open` to `gun:start_link` to start the gun process.
+  This makes the gun process linked to `ehttpc` process (instead of `gun_sup`).
+  Prior to this change, some early errors causing gun process to crash might not be able to be caught by ehttpc due to the slow monitoring.
+  e.g. when some SSL option is invalid, the gun process will crash immediately and `ehttpc` can only get a `noproc` error reason from the delayed process monitor.
+
 ## 0.4.11
 
 - Added support for `PATCH` method requests.

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps, [
-    {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}},
+    {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.10"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.7"}}}
 ]}.
@@ -34,3 +34,4 @@
 {cover_export_enabled, true}.
 
 {plugins, [rebar3_proper, erlfmt]}.
+{dialyzer, [{plt_extra_apps, [ssl, public_key]}]}.

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,15 +1,16 @@
-{application, ehttpc,
- [{description, "HTTP Client for Erlang/OTP"},
-  {vsn, "0.4.11"},
-  {registered, []},
-  {applications, [kernel,
-                  stdlib,
-                  gproc,
-                  gun
-                 ]},
-  {mod, {ehttpc_app, []}},
-  {env, []},
-  {licenses,["Apache-2.0"]},
-  {maintainers, ["EMQX Team <contact@emqx.io>"]},
-  {links,[{"Github", "https://github.com/emqx/ehttpc"}]}
- ]}.
+{application, ehttpc, [
+    {description, "HTTP Client for Erlang/OTP"},
+    {vsn, "0.4.12"},
+    {registered, []},
+    {applications, [
+        kernel,
+        stdlib,
+        gproc,
+        gun
+    ]},
+    {mod, {ehttpc_app, []}},
+    {env, []},
+    {licenses, ["Apache-2.0"]},
+    {maintainers, ["EMQX Team <contact@emqx.io>"]},
+    {links, [{"Github", "https://github.com/emqx/ehttpc"}]}
+]}.

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,22 +1,32 @@
 %% -*- mode: erlang -*-
-{"0.4.11",
+{"0.4.12",
    [
+     {"0.4.11", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     ]},
      {"0.4.10", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.9", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.8", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.7", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.6", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.5", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.4\\.[0-4]">>, [
@@ -63,22 +73,32 @@
      ]}
    ],
    [
+     {"0.4.11", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
+       {load_module, ehttpc, brutal_purge, soft_purge, []}
+     ]},
      {"0.4.10", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.9", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
     {"0.4.8", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
     {"0.4.7", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.6", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {"0.4.5", [
+       {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
      ]},
      {<<"0\\.4\\.[0-4]">>, [

--- a/src/ehttpc_app.erl
+++ b/src/ehttpc_app.erl
@@ -26,4 +26,3 @@ start(_StartType, _StartArgs) ->
 
 stop(_State) ->
     ok.
-

--- a/src/ehttpc_pool_sup.erl
+++ b/src/ehttpc_pool_sup.erl
@@ -28,16 +28,22 @@ start_link(Pool, Opts) ->
     supervisor:start_link(?MODULE, [Pool, Opts]).
 
 init([Pool, Opts]) ->
-    Specs = [#{id => pool,
-               start => {ehttpc_pool, start_link, [Pool, Opts]},
-               restart => transient,
-               shutdown => 5000,
-               type => worker,
-               modules => [ehttpc_pool]},
-             #{id => worker_sup,
-               start => {ehttpc_worker_sup, start_link, [Pool, Opts]},
-               restart => transient,
-               shutdown => 5000,
-               type => supervisor,
-               modules => [ehttpc_worker_sup]}],
+    Specs = [
+        #{
+            id => pool,
+            start => {ehttpc_pool, start_link, [Pool, Opts]},
+            restart => transient,
+            shutdown => 5000,
+            type => worker,
+            modules => [ehttpc_pool]
+        },
+        #{
+            id => worker_sup,
+            start => {ehttpc_worker_sup, start_link, [Pool, Opts]},
+            restart => transient,
+            shutdown => 5000,
+            type => supervisor,
+            modules => [ehttpc_worker_sup]
+        }
+    ],
     {ok, {{one_for_all, 10, 100}, Specs}}.

--- a/src/ehttpc_sup.erl
+++ b/src/ehttpc_sup.erl
@@ -21,9 +21,10 @@
 -export([start_link/0]).
 
 %% API
--export([ start_pool/2
-        , stop_pool/1
-        ]).
+-export([
+    start_pool/2,
+    stop_pool/1
+]).
 
 %% Supervisor callbacks
 -export([init/1]).
@@ -46,26 +47,28 @@ start_pool(Pool, Opts) ->
 -spec stop_pool(Pool :: ehttpc:pool_name()) -> ok | {error, term()}.
 stop_pool(Pool) ->
     ChildId = child_id(Pool),
-	case supervisor:terminate_child(?MODULE, ChildId) of
+    case supervisor:terminate_child(?MODULE, ChildId) of
         ok ->
             supervisor:delete_child(?MODULE, ChildId);
         {error, not_found} ->
             ok
-	end.
+    end.
 
 %%--------------------------------------------------------------------
 %% Supervisor callbacks
 %%--------------------------------------------------------------------
 
 init([]) ->
-    {ok, { {one_for_one, 10, 100}, []} }.
+    {ok, {{one_for_one, 10, 100}, []}}.
 
 pool_spec(Pool, Opts) ->
-    #{id => child_id(Pool),
-      start => {ehttpc_pool_sup, start_link, [Pool, Opts]},
-      restart => transient,
-      shutdown => 5000,
-      type => supervisor,
-      modules => [ehttpc_pool_sup]}.
+    #{
+        id => child_id(Pool),
+        start => {ehttpc_pool_sup, start_link, [Pool, Opts]},
+        restart => transient,
+        shutdown => 5000,
+        type => supervisor,
+        modules => [ehttpc_pool_sup]
+    }.
 
 child_id(Pool) -> {ehttpc_pool_sup, Pool}.

--- a/src/ehttpc_worker_sup.erl
+++ b/src/ehttpc_worker_sup.erl
@@ -27,17 +27,18 @@ start_link(Pool, Opts) ->
 
 init([Pool, Opts]) ->
     WorkerSpec = fun(Id) ->
-                     #{id => {worker, Id},
-                       start => {ehttpc, start_link, [Pool, Id, Opts]},
-                       restart => transient,
-                       shutdown => 5000,
-                       type => worker,
-                       modules => [ehttpc]}
-                 end,
+        #{
+            id => {worker, Id},
+            start => {ehttpc, start_link, [Pool, Id, Opts]},
+            restart => transient,
+            shutdown => 5000,
+            type => worker,
+            modules => [ehttpc]
+        }
+    end,
     Workers = [WorkerSpec(I) || I <- lists:seq(1, pool_size(Opts))],
     {ok, {{one_for_one, 10, 60}, Workers}}.
 
 pool_size(Opts) ->
     Schedulers = erlang:system_info(schedulers),
     proplists:get_value(pool_size, Opts, Schedulers).
-

--- a/test/ehttpc_tests.erl
+++ b/test/ehttpc_tests.erl
@@ -280,108 +280,89 @@ health_check_abnormal_test_() ->
     Unreachable = "8.8.8.8",
     Unknown = "unknown-host0",
     [
-        {timeout, 20, fun() ->
-            ?WITH(
-                #{
-                    port => Port,
-                    name => ?FUNCTION_NAME,
-                    delay => 0
-                },
-                pool_opts(Port, true),
-                begin
-                    Worker = ehttpc_pool:pick_worker(?POOL),
-                    %% 1. Do health_check with very short timeout,
-                    %% The check failed but ehttpc is still trying to establish
-                    %% the connection.
-                    ?assertEqual(
-                        {error, connect_timeout},
-                        ehttpc:health_check(Worker, 0)
-                    ),
-                    %% 2. do health_check again should be OK.
-                    ?assertEqual(ok, ehttpc:health_check(Worker, timer:seconds(2))),
-                    {ok, _} = ?block_until(
-                        #{?snk_kind := health_check_when_gun_client_not_ready},
-                        1000,
-                        infinity
-                    )
-                end
-            )
-        end},
-        {timeout, 20, fun() ->
-            ?WITH(
-                #{
-                    port => Port,
-                    name => ?FUNCTION_NAME,
-                    delay => 0
-                },
-                pool_opts(Port, true),
-                begin
-                    Worker = ehttpc_pool:pick_worker(?POOL),
-                    exit(Worker, kill),
-                    ?assertMatch(
-                        {error, {ehttpc_worker_down, _}},
-                        ehttpc:health_check(Worker, 5_000)
-                    )
-                end
-            )
-        end},
-        {timeout, 20, fun() ->
-            ?WITH(
-                #{
-                    port => Port,
-                    name => ?FUNCTION_NAME,
-                    delay => 0
-                },
-                pool_opts(Unreachable, Port, true),
-                begin
-                    Worker = ehttpc_pool:pick_worker(?POOL),
-                    ?assertEqual(
-                        {error, connect_timeout},
-                        ehttpc:health_check(Worker, 5_000)
-                    )
-                end
-            )
-        end},
-        {timeout, 20, fun() ->
-            ?WITH(
-                #{
-                    port => Port,
-                    name => ?FUNCTION_NAME,
-                    delay => 0
-                },
-                pool_opts(Unknown, Port, true),
-                begin
-                    Worker = ehttpc_pool:pick_worker(?POOL),
-                    ?assertEqual(
-                        {error, nxdomain},
-                        ehttpc:health_check(Worker, 5_000)
-                    )
-                end
-            )
-        end},
-        {timeout, 20, fun() ->
-            ?WITH(
-                #{
-                    port => Port,
-                    name => ?FUNCTION_NAME,
-                    delay => 0
-                },
-                [
-                    {host, "127.0.0.1"},
-                    {port, ?PORT},
-                    {pool_size, 1},
-                    {pool_type, random},
-                    {connect_timeout, invalid_val}
-                ],
-                begin
-                    Worker = ehttpc_pool:pick_worker(?POOL),
-                    ?assertEqual(
-                        {error, {options, {connect_timeout, invalid_val}}},
-                        ehttpc:health_check(Worker, 5_000)
-                    )
-                end
-            )
-        end}
+        {timeout, 20,
+            {"connect timeout", fun() ->
+                ?WITH(
+                    #{
+                        port => Port,
+                        name => ?FUNCTION_NAME,
+                        delay => 0
+                    },
+                    pool_opts(Port, true),
+                    begin
+                        Worker = ehttpc_pool:pick_worker(?POOL),
+                        %% 1. Do health_check with very short timeout,
+                        %% The check failed but ehttpc is still trying to establish
+                        %% the connection.
+                        ?assertEqual(
+                            {error, connect_timeout},
+                            ehttpc:health_check(Worker, 0)
+                        ),
+                        %% 2. do health_check again should be OK.
+                        ?assertEqual(ok, ehttpc:health_check(Worker, timer:seconds(2))),
+                        {ok, _} = ?block_until(
+                            #{?snk_kind := health_check_when_gun_client_not_ready},
+                            1000,
+                            infinity
+                        )
+                    end
+                )
+            end}},
+        {timeout, 20,
+            {"kill pool worker", fun() ->
+                ?WITH(
+                    #{
+                        port => Port,
+                        name => ?FUNCTION_NAME,
+                        delay => 0
+                    },
+                    pool_opts(Port, true),
+                    begin
+                        Worker = ehttpc_pool:pick_worker(?POOL),
+                        exit(Worker, kill),
+                        ?assertMatch(
+                            {error, {ehttpc_worker_down, _}},
+                            ehttpc:health_check(Worker, 5_000)
+                        )
+                    end
+                )
+            end}},
+        {timeout, 20,
+            {"unreachable host", fun() ->
+                ?WITH(
+                    #{
+                        port => Port,
+                        name => ?FUNCTION_NAME,
+                        delay => 0
+                    },
+                    pool_opts(Unreachable, Port, true),
+                    begin
+                        Worker = ehttpc_pool:pick_worker(?POOL),
+                        ?assertEqual(
+                            {error, connect_timeout},
+                            ehttpc:health_check(Worker, 5_000)
+                        )
+                    end
+                )
+            end}},
+        {timeout, 20,
+            {"nxdomain", fun() ->
+                ?WITH(
+                    #{
+                        port => Port,
+                        name => ?FUNCTION_NAME,
+                        delay => 0
+                    },
+                    pool_opts(Unknown, Port, true),
+                    begin
+                        Worker = ehttpc_pool:pick_worker(?POOL),
+                        ?assertEqual(
+                            {error, nxdomain},
+                            ehttpc:health_check(Worker, 5_000)
+                        )
+                    end
+                )
+            end}}
     ].
 
 server_outage_test_() ->


### PR DESCRIPTION
- Upgrade to gun 1.3.10 (OTP 26)
- Changed from `gun:open` to `gun:start_link` to start the gun process.
  This makes the gun process linked to `ehttpc` process (instead of `gun_sup`).
  Prior to this change, some early errors causing gun process to crash might not be able to be caught by ehttpc due to the slow monitoring.
  e.g. when some SSL option is invalid, the gun process will crash immediately and `ehttpc` can only get a `noproc` error reason from the delayed process monitor.