### PR TITLE
fix: upgrade to gun 1.3.11

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ehttpc changes
 
+## 0.4.13
+
+- Upgrade to gun 1.3.11.
+  [Fix `host` header](https://github.com/emqx/gun/pull/8)
+
 ## 0.4.12
 
 - Upgrade to gun 1.3.10 (OTP 26)

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {minimum_otp_vsn, "21.0"}.
 
 {deps, [
-    {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.10"}}},
+    {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.11"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.7"}}}
 ]}.

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc, [
     {description, "HTTP Client for Erlang/OTP"},
-    {vsn, "0.4.12"},
+    {vsn, "0.4.13"},
     {registered, []},
     {applications, [
         kernel,

--- a/src/ehttpc.appup.src
+++ b/src/ehttpc.appup.src
@@ -1,6 +1,8 @@
 %% -*- mode: erlang -*-
-{"0.4.12",
+{"0.4.13",
    [
+     {"0.4.12", [ % upgrade gun, no local beam changes in this version
+     ]},
      {"0.4.11", [
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}
@@ -73,6 +75,8 @@
      ]}
    ],
    [
+     {"0.4.12", [ % upgrade gun, no local beam changes in this version
+     ]},
      {"0.4.11", [
        {load_module, ehttpc_pool, brutal_purge, soft_purge, []},
        {load_module, ehttpc, brutal_purge, soft_purge, []}


### PR DESCRIPTION
- Upgrade to gun 1.3.11.
  [Fix `host` header](https://github.com/emqx/gun/pull/8)