### PR TITLE
fix: async reply for expired requests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ehttpc changes
 
+## 0.7.1
+
+- Reply error to async callbacks when request expired.
+
 ## 0.7.0
 
 - Switch to `gun` 2.1.0.


### PR DESCRIPTION
prior to this fix, callback style async requests are not replied if a request is expired.
fixed to always evaluate the callback, but do not send reply for gen_server calls.