### PR TITLE
chore: set_lable for debugging and log pool/id for zombie ehttpc

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ehttpc changes
 
+## 0.7.1
+
+- Add `pool` and `id` to the worker process label.
+
 ## 0.7.0
 
 - Switch to `gun` 2.1.0.

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc, [
     {description, "HTTP Client for Erlang/OTP"},
-    {vsn, "0.7.0"},
+    {vsn, "0.7.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/src/ehttpc_worker_sup.erl
+++ b/src/ehttpc_worker_sup.erl
@@ -28,7 +28,7 @@ start_link(Pool, Opts) ->
 init([Pool, Opts]) ->
     WorkerSpec = fun(Id) ->
         #{
-            id => {worker, Id},
+            id => {Pool, Id},
             start => {ehttpc, start_link, [Pool, Id, Opts]},
             restart => transient,
             shutdown => 5000,


### PR DESCRIPTION
Working on OTP 27 (e5.9.0)
<img width="1177" alt="image" src="https://github.com/user-attachments/assets/e8567ca3-a9ee-45de-9119-6b4c51445f02" />
