### PR TITLE
fix: make max restart intensity proportional to pool size

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,15 @@
 # ehttpc changes
 
+## 0.7.3
+
+- Previously, we had a fixed restart intensity for the worker supervisor, meaning that if a
+  large pool dies once, it brings down the supervisor. Here, we have an intensity
+  proportional to the pool size, so the whole pool may restart at once without bringing the
+  supervisor down.
+- Added an `ehttpc:check_pool_integrity/1` function to check whether the supervision tree
+  is whole (i.e., no children of the root supervisor are permanently dead and won't be
+  restarted).
+
 ## 0.7.2
 
 - Fix rebar.config.

--- a/src/ehttpc.app.src
+++ b/src/ehttpc.app.src
@@ -1,6 +1,6 @@
 {application, ehttpc, [
     {description, "HTTP Client for Erlang/OTP"},
-    {vsn, "0.7.1"},
+    {vsn, "0.7.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/src/ehttpc.erl
+++ b/src/ehttpc.erl
@@ -32,6 +32,7 @@
     request_async/5,
     workers/1,
     health_check/2,
+    check_pool_integrity/1,
     name/1
 ]).
 
@@ -234,6 +235,11 @@ mk_async_request(delete = Method, Req, ExpireAt, RC) when ?IS_HEADERS_REQ(Req) -
 
 workers(Pool) ->
     gproc_pool:active_workers(name(Pool)).
+
+-spec check_pool_integrity(pool_name()) ->
+    ok | {error, {processes_down, [root | pool | worker_sup]} | not_found}.
+check_pool_integrity(Pool) ->
+    ehttpc_sup:check_pool_integrity(Pool).
 
 name(Pool) -> {?MODULE, Pool}.
 


### PR DESCRIPTION
See also https://github.com/emqx/ecpool/pull/59

See also https://emqx.atlassian.net/browse/EMQX-14705

Previously, we had a fixed restart intensity for the worker supervisor, meaning that if a
large pool dies once, it brings down the supervisor. Here, we have an intensity
proportional to the pool size, so the whole pool may restart at once without bringing the
supervisor down.