### PR TITLE
fix: clarify 0.6.0 changelog wording

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@
 - Add `max_inactive` duration option (default is `10_000` milliseconds).
   This is to detect zombie connections especially when pipelining is set > 1.
   With `{max_inactive, 10_000}` added to the `start_pool` option,
-  it will try to reconnect HTTP server up on detection of the last sent request had been expired for 10 seconds.
+  it will try to reconnect when inflight requests remain unanswered for 10 seconds past their request timeout.
 
 ## 0.5.0
 


### PR DESCRIPTION
## Summary

Clarify the `0.6.0` changelog entry for `max_inactive` so it matches the implemented behavior.

## Notes

- No code changes
- Changelog wording only
